### PR TITLE
feat: add sync sync engine and outbox

### DIFF
--- a/lib/data/local_database.dart
+++ b/lib/data/local_database.dart
@@ -1,0 +1,1393 @@
+import 'dart:convert';
+
+import 'package:flutter/widgets.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../models/item_model.dart';
+import '../models/space_member.dart';
+import '../models/space_model.dart';
+import '../models/user_profile.dart';
+import 'remote/models.dart';
+
+class LocalDatabase {
+  LocalDatabase({DatabaseFactory? factory})
+      : _databaseFactory = factory ?? databaseFactory;
+
+  final DatabaseFactory _databaseFactory;
+  Database? _database;
+
+  static const _dbName = 'spaces.db';
+  static const _dbVersion = 3;
+
+  Future<Database> _openDatabase() async {
+    final existing = _database;
+    if (existing != null) {
+      return existing;
+    }
+
+    final directory = await getApplicationDocumentsDirectory();
+    final path = p.join(directory.path, _dbName);
+    final db = await _databaseFactory.openDatabase(
+      path,
+      options: OpenDatabaseOptions(
+        version: _dbVersion,
+        onConfigure: (db) async {
+          await db.execute('PRAGMA foreign_keys = ON');
+        },
+        onCreate: (db, version) async {
+          await db.execute('''
+            CREATE TABLE spaces (
+              id TEXT PRIMARY KEY,
+              name TEXT NOT NULL,
+              position_dx REAL NOT NULL,
+              position_dy REAL NOT NULL,
+              size_width REAL NOT NULL,
+              size_height REAL NOT NULL,
+              parent_id TEXT,
+              updated_at INTEGER NOT NULL,
+              version INTEGER NOT NULL,
+              is_deleted INTEGER NOT NULL
+            );
+          ''');
+
+          await db.execute('''
+            CREATE TABLE items (
+              id TEXT PRIMARY KEY,
+              space_id TEXT NOT NULL,
+              name TEXT NOT NULL,
+              description TEXT NOT NULL,
+              location_specification TEXT,
+              tags_json TEXT,
+              image_path TEXT,
+              updated_at INTEGER NOT NULL,
+              version INTEGER NOT NULL,
+              is_deleted INTEGER NOT NULL,
+              FOREIGN KEY(space_id) REFERENCES spaces(id) ON DELETE CASCADE
+            );
+          ''');
+
+          await db.execute(
+            'CREATE INDEX idx_items_space_id ON items(space_id);',
+          );
+
+          await _createSharingTables(db);
+          await _createSyncTables(db);
+        },
+        onUpgrade: (db, oldVersion, newVersion) async {
+          if (oldVersion < 2) {
+            await _createSharingTables(db);
+          }
+          if (oldVersion < 3) {
+            await _createSyncTables(db);
+          }
+        },
+      ),
+    );
+    _database = db;
+    return db;
+  }
+
+  static Future<void> _createSharingTables(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL,
+        display_name TEXT,
+        avatar_url TEXT,
+        is_current INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        version INTEGER NOT NULL,
+        is_deleted INTEGER NOT NULL
+      );
+    ''');
+
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS space_memberships (
+        space_id TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        joined_at INTEGER,
+        attachment_visibility TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        version INTEGER NOT NULL,
+        is_deleted INTEGER NOT NULL,
+        PRIMARY KEY (space_id, user_id),
+        FOREIGN KEY(space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+        FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+      );
+    ''');
+
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_space_memberships_space_id ON space_memberships(space_id);',
+    );
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_space_memberships_user_id ON space_memberships(user_id);',
+    );
+  }
+
+  static Future<void> _createSyncTables(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS outbox (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL,
+        entity_id TEXT NOT NULL,
+        space_id TEXT,
+        operation TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        version INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+    ''');
+
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_outbox_entity ON outbox(entity_type, entity_id);',
+    );
+  }
+
+  Future<void> replaceAllSpaces(List<SpaceModel> spaces) async {
+    final db = await _openDatabase();
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+
+    final usersById = <String, UserProfile>{};
+
+    void collectMembers(SpaceModel space) {
+      for (final member in space.collaborators) {
+        usersById[member.user.id] = member.user;
+      }
+      for (final child in space.mySpaces) {
+        collectMembers(child);
+      }
+    }
+
+    for (final root in spaces) {
+      collectMembers(root);
+    }
+
+    await db.transaction((txn) async {
+      final existingSpaces = await _loadRowsByPrimaryKey(txn, 'spaces', 'id');
+      final existingItems = await _loadRowsByPrimaryKey(txn, 'items', 'id');
+      final existingUsers = await _loadRowsByPrimaryKey(txn, 'users', 'id');
+      final existingMemberships = await _loadMembershipRows(txn);
+
+      Future<void> upsertUser(UserProfile user) async {
+        final existing = existingUsers.remove(user.id);
+        final newRow = <String, Object?>{
+          'id': user.id,
+          'email': user.email,
+          'display_name': user.displayName,
+          'avatar_url': user.avatarUrl,
+          'is_current': user.isCurrentUser ? 1 : 0,
+          'is_deleted': 0,
+        };
+        final shouldRevive = existing != null && _isDeleted(existing);
+        final hasChanges = _hasChanged(
+          existing,
+          newRow,
+          const ['email', 'display_name', 'avatar_url', 'is_current'],
+        );
+        if (existing == null) {
+          final version = 1;
+          await txn.insert(
+            'users',
+            {
+              ...newRow,
+              'updated_at': timestamp,
+              'version': version,
+            },
+            conflictAlgorithm: ConflictAlgorithm.replace,
+          );
+          await _enqueueMutation(
+            txn,
+            entityType: 'user',
+            entityId: user.id,
+            operation: 'upsert',
+            payload: _userPayload(
+              id: user.id,
+              email: user.email,
+              displayName: user.displayName,
+              avatarUrl: user.avatarUrl,
+              isCurrentUser: user.isCurrentUser,
+              isDeleted: false,
+              updatedAt: timestamp,
+              version: version,
+            ),
+            updatedAt: timestamp,
+            version: version,
+          );
+        } else if (shouldRevive || hasChanges) {
+          final version = ((existing['version'] as int?) ?? 0) + 1;
+          await txn.update(
+            'users',
+            {
+              ...newRow,
+              'updated_at': timestamp,
+              'version': version,
+            },
+            where: 'id = ?',
+            whereArgs: [user.id],
+          );
+          await _enqueueMutation(
+            txn,
+            entityType: 'user',
+            entityId: user.id,
+            operation: 'upsert',
+            payload: _userPayload(
+              id: user.id,
+              email: user.email,
+              displayName: user.displayName,
+              avatarUrl: user.avatarUrl,
+              isCurrentUser: user.isCurrentUser,
+              isDeleted: false,
+              updatedAt: timestamp,
+              version: version,
+            ),
+            updatedAt: timestamp,
+            version: version,
+          );
+        }
+      }
+
+      for (final user in usersById.values) {
+        await upsertUser(user);
+      }
+
+      Future<void> persistSpace(
+        SpaceModel space,
+        String? parentId,
+      ) async {
+        final spaceId = space.id;
+        final existing = existingSpaces.remove(spaceId);
+        final newRow = <String, Object?>{
+          'id': spaceId,
+          'name': space.name,
+          'position_dx': space.position.dx,
+          'position_dy': space.position.dy,
+          'size_width': space.size.width,
+          'size_height': space.size.height,
+          'parent_id': parentId,
+          'is_deleted': 0,
+        };
+        final shouldRevive = existing != null && _isDeleted(existing);
+        final hasChanges = _hasChanged(
+          existing,
+          newRow,
+          const [
+            'name',
+            'position_dx',
+            'position_dy',
+            'size_width',
+            'size_height',
+            'parent_id',
+          ],
+        );
+        if (existing == null) {
+          final version = 1;
+          await txn.insert(
+            'spaces',
+            {
+              ...newRow,
+              'updated_at': timestamp,
+              'version': version,
+            },
+            conflictAlgorithm: ConflictAlgorithm.replace,
+          );
+          await _enqueueMutation(
+            txn,
+            entityType: 'space',
+            entityId: spaceId,
+            operation: 'upsert',
+            payload: _spacePayload(
+              spaceId: spaceId,
+              name: space.name,
+              position: space.position,
+              size: space.size,
+              parentId: parentId,
+              isDeleted: false,
+              updatedAt: timestamp,
+              version: version,
+            ),
+            updatedAt: timestamp,
+            version: version,
+            spaceId: spaceId,
+          );
+        } else if (shouldRevive || hasChanges) {
+          final version = ((existing['version'] as int?) ?? 0) + 1;
+          await txn.update(
+            'spaces',
+            {
+              ...newRow,
+              'updated_at': timestamp,
+              'version': version,
+            },
+            where: 'id = ?',
+            whereArgs: [spaceId],
+          );
+          await _enqueueMutation(
+            txn,
+            entityType: 'space',
+            entityId: spaceId,
+            operation: 'upsert',
+            payload: _spacePayload(
+              spaceId: spaceId,
+              name: space.name,
+              position: space.position,
+              size: space.size,
+              parentId: parentId,
+              isDeleted: false,
+              updatedAt: timestamp,
+              version: version,
+            ),
+            updatedAt: timestamp,
+            version: version,
+            spaceId: spaceId,
+          );
+        }
+
+        final itemIdsForSpace = <String>{};
+        for (final item in space.items) {
+          final itemId = item.id;
+          itemIdsForSpace.add(itemId);
+          final existingItem = existingItems.remove(itemId);
+          final tagsJson =
+              item.tags == null ? null : jsonEncode(List<String>.from(item.tags!));
+          final newItemRow = <String, Object?>{
+            'id': itemId,
+            'space_id': spaceId,
+            'name': item.name,
+            'description': item.description,
+            'location_specification': item.locationSpecification,
+            'tags_json': tagsJson,
+            'image_path': item.imagePath,
+            'is_deleted': 0,
+          };
+          final itemRevived = existingItem != null && _isDeleted(existingItem);
+          final itemChanged = _hasChanged(
+            existingItem,
+            newItemRow,
+            const [
+              'space_id',
+              'name',
+              'description',
+              'location_specification',
+              'tags_json',
+              'image_path',
+            ],
+          );
+          if (existingItem == null) {
+            final version = 1;
+            await txn.insert(
+              'items',
+              {
+                ...newItemRow,
+                'updated_at': timestamp,
+                'version': version,
+              },
+              conflictAlgorithm: ConflictAlgorithm.replace,
+            );
+            await _enqueueMutation(
+              txn,
+              entityType: 'item',
+              entityId: itemId,
+              operation: 'upsert',
+              payload: _itemPayload(
+                id: itemId,
+                spaceId: spaceId,
+                name: item.name,
+                description: item.description,
+                locationSpecification: item.locationSpecification,
+                tags: item.tags,
+                imagePath: item.imagePath,
+                isDeleted: false,
+                updatedAt: timestamp,
+                version: version,
+              ),
+              updatedAt: timestamp,
+              version: version,
+              spaceId: spaceId,
+            );
+          } else if (itemRevived || itemChanged) {
+            final version = ((existingItem['version'] as int?) ?? 0) + 1;
+            await txn.update(
+              'items',
+              {
+                ...newItemRow,
+                'updated_at': timestamp,
+                'version': version,
+              },
+              where: 'id = ?',
+              whereArgs: [itemId],
+            );
+            await _enqueueMutation(
+              txn,
+              entityType: 'item',
+              entityId: itemId,
+              operation: 'upsert',
+              payload: _itemPayload(
+                id: itemId,
+                spaceId: spaceId,
+                name: item.name,
+                description: item.description,
+                locationSpecification: item.locationSpecification,
+                tags: item.tags,
+                imagePath: item.imagePath,
+                isDeleted: false,
+                updatedAt: timestamp,
+                version: version,
+              ),
+              updatedAt: timestamp,
+              version: version,
+              spaceId: spaceId,
+            );
+          }
+        }
+
+        for (final itemEntry in existingItems.entries.toList()) {
+          final row = itemEntry.value;
+          if (row['space_id'] != spaceId) {
+            continue;
+          }
+          final itemId = itemEntry.key;
+          if (itemIdsForSpace.contains(itemId)) {
+            continue;
+          }
+          if (_isDeleted(row)) {
+            existingItems.remove(itemId);
+            continue;
+          }
+          final version = ((row['version'] as int?) ?? 0) + 1;
+          await txn.update(
+            'items',
+            {
+              'is_deleted': 1,
+              'updated_at': timestamp,
+              'version': version,
+            },
+            where: 'id = ?',
+            whereArgs: [itemId],
+          );
+          await _enqueueMutation(
+            txn,
+            entityType: 'item',
+            entityId: itemId,
+            operation: 'delete',
+            payload: {
+              'id': itemId,
+              'spaceId': row['space_id'],
+              'isDeleted': true,
+              'updatedAt': timestamp,
+              'version': version,
+            },
+            updatedAt: timestamp,
+            version: version,
+            spaceId: row['space_id'] as String?,
+          );
+          existingItems.remove(itemId);
+        }
+
+        final membershipsForSpace = <String>{};
+        for (final member in space.collaborators) {
+          final membershipKey = _membershipKey(spaceId, member.user.id);
+          membershipsForSpace.add(membershipKey);
+          final existingMembership = existingMemberships.remove(membershipKey);
+          final newMembershipRow = <String, Object?>{
+            'space_id': spaceId,
+            'user_id': member.user.id,
+            'role': member.role.name,
+            'joined_at': member.joinedAt?.millisecondsSinceEpoch,
+            'attachment_visibility':
+                member.defaultAttachmentVisibility.name,
+            'is_deleted': 0,
+          };
+          final membershipRevived =
+              existingMembership != null && _isDeleted(existingMembership);
+          final membershipChanged = _hasChanged(
+            existingMembership,
+            newMembershipRow,
+            const [
+              'role',
+              'joined_at',
+              'attachment_visibility',
+            ],
+          );
+          if (existingMembership == null) {
+            final version = 1;
+            await txn.insert(
+              'space_memberships',
+              {
+                ...newMembershipRow,
+                'updated_at': timestamp,
+                'version': version,
+              },
+              conflictAlgorithm: ConflictAlgorithm.replace,
+            );
+            await _enqueueMutation(
+              txn,
+              entityType: 'space_membership',
+              entityId: membershipKey,
+              operation: 'upsert',
+              payload: _membershipPayload(
+                spaceId: spaceId,
+                userId: member.user.id,
+                role: member.role.name,
+                attachmentVisibility:
+                    member.defaultAttachmentVisibility.name,
+                joinedAt: member.joinedAt,
+                isDeleted: false,
+                updatedAt: timestamp,
+                version: version,
+              ),
+              updatedAt: timestamp,
+              version: version,
+              spaceId: spaceId,
+            );
+          } else if (membershipRevived || membershipChanged) {
+            final version = ((existingMembership['version'] as int?) ?? 0) + 1;
+            await txn.update(
+              'space_memberships',
+              {
+                ...newMembershipRow,
+                'updated_at': timestamp,
+                'version': version,
+              },
+              where: 'space_id = ? AND user_id = ?',
+              whereArgs: [spaceId, member.user.id],
+            );
+            await _enqueueMutation(
+              txn,
+              entityType: 'space_membership',
+              entityId: membershipKey,
+              operation: 'upsert',
+              payload: _membershipPayload(
+                spaceId: spaceId,
+                userId: member.user.id,
+                role: member.role.name,
+                attachmentVisibility:
+                    member.defaultAttachmentVisibility.name,
+                joinedAt: member.joinedAt,
+                isDeleted: false,
+                updatedAt: timestamp,
+                version: version,
+              ),
+              updatedAt: timestamp,
+              version: version,
+              spaceId: spaceId,
+            );
+          }
+        }
+
+        for (final membershipEntry in existingMemberships.entries.toList()) {
+          final row = membershipEntry.value;
+          if (row['space_id'] != spaceId) {
+            continue;
+          }
+          final key = membershipEntry.key;
+          if (membershipsForSpace.contains(key)) {
+            continue;
+          }
+          if (_isDeleted(row)) {
+            existingMemberships.remove(key);
+            continue;
+          }
+          final version = ((row['version'] as int?) ?? 0) + 1;
+          final spaceIdValue = row['space_id'] as String;
+          final userIdValue = row['user_id'] as String;
+          await txn.update(
+            'space_memberships',
+            {
+              'is_deleted': 1,
+              'updated_at': timestamp,
+              'version': version,
+            },
+            where: 'space_id = ? AND user_id = ?',
+            whereArgs: [spaceIdValue, userIdValue],
+          );
+          await _enqueueMutation(
+            txn,
+            entityType: 'space_membership',
+            entityId: key,
+            operation: 'delete',
+            payload: {
+              'spaceId': spaceIdValue,
+              'userId': userIdValue,
+              'isDeleted': true,
+              'updatedAt': timestamp,
+              'version': version,
+            },
+            updatedAt: timestamp,
+            version: version,
+            spaceId: spaceIdValue,
+          );
+          existingMemberships.remove(key);
+        }
+
+        for (final child in space.mySpaces) {
+          await persistSpace(child, spaceId);
+        }
+      }
+
+      for (final root in spaces) {
+        await persistSpace(root, null);
+      }
+
+      for (final entry in existingSpaces.entries) {
+        final row = entry.value;
+        if (_isDeleted(row)) {
+          continue;
+        }
+        final version = ((row['version'] as int?) ?? 0) + 1;
+        await txn.update(
+          'spaces',
+          {
+            'is_deleted': 1,
+            'updated_at': timestamp,
+            'version': version,
+          },
+          where: 'id = ?',
+          whereArgs: [entry.key],
+        );
+        await _enqueueMutation(
+          txn,
+          entityType: 'space',
+          entityId: entry.key,
+          operation: 'delete',
+          payload: {
+            'id': entry.key,
+            'isDeleted': true,
+            'updatedAt': timestamp,
+            'version': version,
+          },
+          updatedAt: timestamp,
+          version: version,
+          spaceId: entry.key,
+        );
+      }
+
+      for (final entry in existingItems.entries) {
+        final row = entry.value;
+        if (_isDeleted(row)) {
+          continue;
+        }
+        final version = ((row['version'] as int?) ?? 0) + 1;
+        await txn.update(
+          'items',
+          {
+            'is_deleted': 1,
+            'updated_at': timestamp,
+            'version': version,
+          },
+          where: 'id = ?',
+          whereArgs: [entry.key],
+        );
+        await _enqueueMutation(
+          txn,
+          entityType: 'item',
+          entityId: entry.key,
+          operation: 'delete',
+          payload: {
+            'id': entry.key,
+            'spaceId': entry.value['space_id'],
+            'isDeleted': true,
+            'updatedAt': timestamp,
+            'version': version,
+          },
+          updatedAt: timestamp,
+          version: version,
+          spaceId: entry.value['space_id'] as String?,
+        );
+      }
+
+      for (final entry in existingMemberships.entries) {
+        final row = entry.value;
+        if (_isDeleted(row)) {
+          continue;
+        }
+        final version = ((row['version'] as int?) ?? 0) + 1;
+        final spaceIdValue = row['space_id'] as String;
+        final userIdValue = row['user_id'] as String;
+        await txn.update(
+          'space_memberships',
+          {
+            'is_deleted': 1,
+            'updated_at': timestamp,
+            'version': version,
+          },
+          where: 'space_id = ? AND user_id = ?',
+          whereArgs: [spaceIdValue, userIdValue],
+        );
+        await _enqueueMutation(
+          txn,
+          entityType: 'space_membership',
+          entityId: _membershipKey(spaceIdValue, userIdValue),
+          operation: 'delete',
+          payload: {
+            'spaceId': spaceIdValue,
+            'userId': userIdValue,
+            'isDeleted': true,
+            'updatedAt': timestamp,
+            'version': version,
+          },
+          updatedAt: timestamp,
+          version: version,
+          spaceId: spaceIdValue,
+        );
+      }
+
+      for (final entry in existingUsers.entries) {
+        final row = entry.value;
+        if (_isDeleted(row)) {
+          continue;
+        }
+        if ((row['is_current'] as int? ?? 0) == 1) {
+          continue;
+        }
+        final version = ((row['version'] as int?) ?? 0) + 1;
+        await txn.update(
+          'users',
+          {
+            'is_deleted': 1,
+            'updated_at': timestamp,
+            'version': version,
+          },
+          where: 'id = ?',
+          whereArgs: [entry.key],
+        );
+        await _enqueueMutation(
+          txn,
+          entityType: 'user',
+          entityId: entry.key,
+          operation: 'delete',
+          payload: {
+            'id': entry.key,
+            'isDeleted': true,
+            'updatedAt': timestamp,
+            'version': version,
+          },
+          updatedAt: timestamp,
+          version: version,
+        );
+      }
+    });
+  }
+
+  Future<List<SpaceModel>> loadSpaces() async {
+    final db = await _openDatabase();
+
+    final spaceRows = await db.query(
+      'spaces',
+      where: 'is_deleted = ?',
+      whereArgs: [0],
+    );
+
+    if (spaceRows.isEmpty) {
+      return [];
+    }
+
+    final itemRows = await db.query(
+      'items',
+      where: 'is_deleted = ?',
+      whereArgs: [0],
+    );
+
+    final userRows = await db.query(
+      'users',
+      where: 'is_deleted = ?',
+      whereArgs: [0],
+    );
+
+    final membershipRows = await db.query(
+      'space_memberships',
+      where: 'is_deleted = ?',
+      whereArgs: [0],
+    );
+
+    final spacesById = <String, SpaceModel>{};
+    for (final row in spaceRows) {
+      final space = SpaceModel(
+        id: row['id'] as String?,
+        name: row['name'] as String,
+        position: Offset(
+          (row['position_dx'] as num).toDouble(),
+          (row['position_dy'] as num).toDouble(),
+        ),
+        size: Size(
+          (row['size_width'] as num).toDouble(),
+          (row['size_height'] as num).toDouble(),
+        ),
+        mySpaces: const [],
+        items: const [],
+      );
+      spacesById[space.id] = space;
+    }
+
+    for (final row in spaceRows) {
+      final id = row['id'] as String;
+      final parentId = row['parent_id'] as String?;
+      final space = spacesById[id];
+      if (space == null || parentId == null) {
+        continue;
+      }
+      final parent = spacesById[parentId];
+      if (parent != null) {
+        space.parent = parent;
+        parent.mySpaces.add(space);
+      }
+    }
+
+    for (final row in itemRows) {
+      final parentId = row['space_id'] as String;
+      final parent = spacesById[parentId];
+      if (parent == null) {
+        continue;
+      }
+      final tagsJson = row['tags_json'] as String?;
+      final tags = tagsJson == null
+          ? null
+          : List<String>.from(jsonDecode(tagsJson) as List<dynamic>);
+      final item = ItemModel(
+        id: row['id'] as String?,
+        name: row['name'] as String,
+        description: row['description'] as String,
+        locationSpecification: row['location_specification'] as String?,
+        tags: tags,
+        imagePath: row['image_path'] as String?,
+        parent: parent,
+      );
+      parent.items.add(item);
+    }
+
+    final usersById = <String, UserProfile>{};
+    for (final row in userRows) {
+      final id = row['id'] as String;
+      usersById[id] = UserProfile(
+        id: id,
+        email: row['email'] as String,
+        displayName: row['display_name'] as String?,
+        avatarUrl: row['avatar_url'] as String?,
+        isCurrentUser: (row['is_current'] as int) == 1,
+      );
+    }
+
+    for (final row in membershipRows) {
+      final spaceId = row['space_id'] as String;
+      final space = spacesById[spaceId];
+      if (space == null) {
+        continue;
+      }
+
+      final userId = row['user_id'] as String;
+      final user = usersById[userId];
+      if (user == null) {
+        continue;
+      }
+
+      final roleValue = row['role'] as String;
+      final attachmentValue = row['attachment_visibility'] as String;
+      final joinedAtValue = row['joined_at'] as int?;
+      space.collaborators.add(
+        SpaceMember(
+          user: user,
+          role: spaceRoleFromName(roleValue),
+          joinedAt: joinedAtValue == null
+              ? null
+              : DateTime.fromMillisecondsSinceEpoch(joinedAtValue),
+          defaultAttachmentVisibility:
+              attachmentVisibilityFromName(attachmentValue),
+        ),
+      );
+    }
+
+    final roots = <SpaceModel>[];
+    for (final space in spacesById.values) {
+      if (space.parent == null) {
+        roots.add(space);
+      }
+    }
+
+    for (final space in roots) {
+      space.assignParents();
+    }
+
+    return roots;
+  }
+
+  Future<List<PendingMutation>> getPendingMutations({int limit = 50}) async {
+    final db = await _openDatabase();
+    final rows = await db.query(
+      'outbox',
+      orderBy: 'id ASC',
+      limit: limit,
+    );
+    return rows
+        .map(
+          (row) => PendingMutation(
+            id: row['id'] as int,
+            entityType: row['entity_type'] as String,
+            entityId: row['entity_id'] as String,
+            spaceId: row['space_id'] as String?,
+            operation: row['operation'] as String,
+            payload: Map<String, dynamic>.from(
+              jsonDecode(row['payload'] as String) as Map<String, dynamic>,
+            ),
+            updatedAt: DateTime.fromMillisecondsSinceEpoch(
+              row['updated_at'] as int,
+            ),
+            version: row['version'] as int,
+          ),
+        )
+        .toList();
+  }
+
+  Future<void> markMutationsProcessed(List<int> ids) async {
+    if (ids.isEmpty) {
+      return;
+    }
+    final db = await _openDatabase();
+    await db.transaction((txn) async {
+      final placeholders = List.filled(ids.length, '?').join(',');
+      await txn.rawDelete('DELETE FROM outbox WHERE id IN ($placeholders)', ids);
+    });
+  }
+
+  Future<void> applyRemoteChanges(SyncResponse response) async {
+    final db = await _openDatabase();
+    await db.transaction((txn) async {
+      await _applyRemoteUsers(txn, response.users);
+      await _applyRemoteSpaces(txn, response.spaces);
+      await _applyRemoteItems(txn, response.items);
+      await _applyRemoteMemberships(txn, response.memberships);
+    });
+  }
+
+  Future<void> _applyRemoteUsers(
+    Transaction txn,
+    List<RemoteUser> users,
+  ) async {
+    for (final user in users) {
+      final rows = await txn.query(
+        'users',
+        where: 'id = ?',
+        whereArgs: [user.id],
+        limit: 1,
+      );
+      final existing = rows.isEmpty ? null : rows.first;
+      final localVersion = existing == null ? 0 : (existing['version'] as int? ?? 0);
+      final localUpdatedAt =
+          existing == null ? 0 : (existing['updated_at'] as int? ?? 0);
+      final remoteUpdatedAt = user.updatedAt.millisecondsSinceEpoch;
+      if (localVersion > user.version) {
+        continue;
+      }
+      if (localVersion == user.version && localUpdatedAt >= remoteUpdatedAt) {
+        continue;
+      }
+      final data = <String, Object?>{
+        'email': user.email,
+        'display_name': user.displayName,
+        'avatar_url': user.avatarUrl,
+        'is_current': user.isCurrentUser ? 1 : 0,
+        'is_deleted': user.isDeleted ? 1 : 0,
+        'version': user.version,
+        'updated_at': remoteUpdatedAt,
+      };
+      if (existing == null) {
+        await txn.insert(
+          'users',
+          {
+            'id': user.id,
+            ...data,
+          },
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      } else {
+        await txn.update(
+          'users',
+          data,
+          where: 'id = ?',
+          whereArgs: [user.id],
+        );
+      }
+    }
+  }
+
+  Future<void> _applyRemoteSpaces(
+    Transaction txn,
+    List<RemoteSpace> spaces,
+  ) async {
+    for (final space in spaces) {
+      final rows = await txn.query(
+        'spaces',
+        where: 'id = ?',
+        whereArgs: [space.id],
+        limit: 1,
+      );
+      final existing = rows.isEmpty ? null : rows.first;
+      final localVersion = existing == null ? 0 : (existing['version'] as int? ?? 0);
+      final localUpdatedAt =
+          existing == null ? 0 : (existing['updated_at'] as int? ?? 0);
+      final remoteUpdatedAt = space.updatedAt.millisecondsSinceEpoch;
+      if (localVersion > space.version) {
+        continue;
+      }
+      if (localVersion == space.version && localUpdatedAt >= remoteUpdatedAt) {
+        continue;
+      }
+      final data = <String, Object?>{
+        'name': space.name,
+        'position_dx': space.positionDx,
+        'position_dy': space.positionDy,
+        'size_width': space.sizeWidth,
+        'size_height': space.sizeHeight,
+        'parent_id': space.parentId,
+        'is_deleted': space.isDeleted ? 1 : 0,
+        'version': space.version,
+        'updated_at': remoteUpdatedAt,
+      };
+      if (existing == null) {
+        await txn.insert(
+          'spaces',
+          {
+            'id': space.id,
+            ...data,
+          },
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      } else {
+        await txn.update(
+          'spaces',
+          data,
+          where: 'id = ?',
+          whereArgs: [space.id],
+        );
+      }
+    }
+  }
+
+  Future<void> _applyRemoteItems(
+    Transaction txn,
+    List<RemoteItem> items,
+  ) async {
+    for (final item in items) {
+      final rows = await txn.query(
+        'items',
+        where: 'id = ?',
+        whereArgs: [item.id],
+        limit: 1,
+      );
+      final existing = rows.isEmpty ? null : rows.first;
+      final localVersion = existing == null ? 0 : (existing['version'] as int? ?? 0);
+      final localUpdatedAt =
+          existing == null ? 0 : (existing['updated_at'] as int? ?? 0);
+      final remoteUpdatedAt = item.updatedAt.millisecondsSinceEpoch;
+      if (localVersion > item.version) {
+        continue;
+      }
+      if (localVersion == item.version && localUpdatedAt >= remoteUpdatedAt) {
+        continue;
+      }
+      final data = <String, Object?>{
+        'space_id': item.spaceId,
+        'name': item.name,
+        'description': item.description,
+        'location_specification': item.locationSpecification,
+        'tags_json': item.tags == null ? null : jsonEncode(item.tags),
+        'image_path': item.imagePath,
+        'is_deleted': item.isDeleted ? 1 : 0,
+        'version': item.version,
+        'updated_at': remoteUpdatedAt,
+      };
+      if (existing == null) {
+        await txn.insert(
+          'items',
+          {
+            'id': item.id,
+            ...data,
+          },
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      } else {
+        await txn.update(
+          'items',
+          data,
+          where: 'id = ?',
+          whereArgs: [item.id],
+        );
+      }
+    }
+  }
+
+  Future<void> _applyRemoteMemberships(
+    Transaction txn,
+    List<RemoteMembership> memberships,
+  ) async {
+    for (final membership in memberships) {
+      final rows = await txn.query(
+        'space_memberships',
+        where: 'space_id = ? AND user_id = ?',
+        whereArgs: [membership.spaceId, membership.userId],
+        limit: 1,
+      );
+      final existing = rows.isEmpty ? null : rows.first;
+      final localVersion = existing == null ? 0 : (existing['version'] as int? ?? 0);
+      final localUpdatedAt =
+          existing == null ? 0 : (existing['updated_at'] as int? ?? 0);
+      final remoteUpdatedAt = membership.updatedAt.millisecondsSinceEpoch;
+      if (localVersion > membership.version) {
+        continue;
+      }
+      if (localVersion == membership.version &&
+          localUpdatedAt >= remoteUpdatedAt) {
+        continue;
+      }
+      final data = <String, Object?>{
+        'role': membership.role,
+        'joined_at': membership.joinedAt?.millisecondsSinceEpoch,
+        'attachment_visibility': membership.attachmentVisibility,
+        'is_deleted': membership.isDeleted ? 1 : 0,
+        'version': membership.version,
+        'updated_at': remoteUpdatedAt,
+      };
+      if (existing == null) {
+        await txn.insert(
+          'space_memberships',
+          {
+            'space_id': membership.spaceId,
+            'user_id': membership.userId,
+            ...data,
+          },
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      } else {
+        await txn.update(
+          'space_memberships',
+          data,
+          where: 'space_id = ? AND user_id = ?',
+          whereArgs: [membership.spaceId, membership.userId],
+        );
+      }
+    }
+  }
+
+  Future<void> dispose() async {
+    final db = _database;
+    if (db != null) {
+      await db.close();
+      _database = null;
+    }
+  }
+}
+
+Future<Map<String, Map<String, Object?>>> _loadRowsByPrimaryKey(
+  Transaction txn,
+  String table,
+  String column,
+) async {
+  final rows = await txn.query(table);
+  final map = <String, Map<String, Object?>>{};
+  for (final row in rows) {
+    final id = row[column];
+    if (id is String) {
+      map[id] = Map<String, Object?>.from(row);
+    }
+  }
+  return map;
+}
+
+Future<Map<String, Map<String, Object?>>> _loadMembershipRows(
+  Transaction txn,
+) async {
+  final rows = await txn.query('space_memberships');
+  final map = <String, Map<String, Object?>>{};
+  for (final row in rows) {
+    final spaceId = row['space_id'];
+    final userId = row['user_id'];
+    if (spaceId is String && userId is String) {
+      map[_membershipKey(spaceId, userId)] = Map<String, Object?>.from(row);
+    }
+  }
+  return map;
+}
+
+String _membershipKey(String spaceId, String userId) => '$spaceId|$userId';
+
+bool _isDeleted(Map<String, Object?> row) => (row['is_deleted'] as int? ?? 0) == 1;
+
+bool _hasChanged(
+  Map<String, Object?>? existing,
+  Map<String, Object?> updated,
+  List<String> keys,
+) {
+  if (existing == null) {
+    return true;
+  }
+  for (final key in keys) {
+    final existingValue = existing[key];
+    final updatedValue = updated[key];
+    if (!_valueEquals(existingValue, updatedValue)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _valueEquals(Object? a, Object? b) {
+  if (a == null || b == null) {
+    return a == b;
+  }
+  if (a is num && b is num) {
+    return (a.toDouble() - b.toDouble()).abs() < 0.000001;
+  }
+  return a == b;
+}
+
+Future<void> _enqueueMutation(
+  Transaction txn, {
+  required String entityType,
+  required String entityId,
+  String? spaceId,
+  required String operation,
+  required Map<String, dynamic> payload,
+  required int updatedAt,
+  required int version,
+}) async {
+  await txn.insert('outbox', {
+    'entity_type': entityType,
+    'entity_id': entityId,
+    'space_id': spaceId,
+    'operation': operation,
+    'payload': jsonEncode(payload),
+    'updated_at': updatedAt,
+    'version': version,
+    'created_at': DateTime.now().millisecondsSinceEpoch,
+  });
+}
+
+Map<String, dynamic> _spacePayload({
+  required String spaceId,
+  required String name,
+  required Offset position,
+  required Size size,
+  String? parentId,
+  required bool isDeleted,
+  required int updatedAt,
+  required int version,
+}) {
+  return {
+    'id': spaceId,
+    'name': name,
+    'positionDx': position.dx,
+    'positionDy': position.dy,
+    'sizeWidth': size.width,
+    'sizeHeight': size.height,
+    'parentId': parentId,
+    'isDeleted': isDeleted,
+    'updatedAt': updatedAt,
+    'version': version,
+  };
+}
+
+Map<String, dynamic> _itemPayload({
+  required String id,
+  required String spaceId,
+  required String name,
+  required String description,
+  String? locationSpecification,
+  List<String>? tags,
+  String? imagePath,
+  required bool isDeleted,
+  required int updatedAt,
+  required int version,
+}) {
+  return {
+    'id': id,
+    'spaceId': spaceId,
+    'name': name,
+    'description': description,
+    'locationSpecification': locationSpecification,
+    'tags': tags,
+    'imagePath': imagePath,
+    'isDeleted': isDeleted,
+    'updatedAt': updatedAt,
+    'version': version,
+  };
+}
+
+Map<String, dynamic> _membershipPayload({
+  required String spaceId,
+  required String userId,
+  required String role,
+  required String attachmentVisibility,
+  DateTime? joinedAt,
+  required bool isDeleted,
+  required int updatedAt,
+  required int version,
+}) {
+  return {
+    'spaceId': spaceId,
+    'userId': userId,
+    'role': role,
+    'attachmentVisibility': attachmentVisibility,
+    'joinedAt': joinedAt?.millisecondsSinceEpoch,
+    'isDeleted': isDeleted,
+    'updatedAt': updatedAt,
+    'version': version,
+  };
+}
+
+Map<String, dynamic> _userPayload({
+  required String id,
+  required String email,
+  String? displayName,
+  String? avatarUrl,
+  required bool isCurrentUser,
+  required bool isDeleted,
+  required int updatedAt,
+  required int version,
+}) {
+  return {
+    'id': id,
+    'email': email,
+    'displayName': displayName,
+    'avatarUrl': avatarUrl,
+    'isCurrentUser': isCurrentUser,
+    'isDeleted': isDeleted,
+    'updatedAt': updatedAt,
+    'version': version,
+  };
+}
+
+class PendingMutation {
+  PendingMutation({
+    required this.id,
+    required this.entityType,
+    required this.entityId,
+    required this.operation,
+    required this.payload,
+    required this.updatedAt,
+    required this.version,
+    this.spaceId,
+  });
+
+  final int id;
+  final String entityType;
+  final String entityId;
+  final String operation;
+  final Map<String, dynamic> payload;
+  final DateTime updatedAt;
+  final int version;
+  final String? spaceId;
+
+  SyncMutation toSyncMutation() {
+    return SyncMutation(
+      entityType: entityType,
+      entityId: entityId,
+      operation: operation,
+      payload: payload,
+      version: version,
+      updatedAt: updatedAt,
+      spaceId: spaceId,
+    );
+  }
+}

--- a/lib/data/remote/models.dart
+++ b/lib/data/remote/models.dart
@@ -1,0 +1,367 @@
+import 'dart:convert';
+
+typedef JsonMap = Map<String, dynamic>;
+
+double _toDouble(dynamic value) {
+  if (value is num) {
+    return value.toDouble();
+  }
+  return double.parse(value.toString());
+}
+
+class RemoteSpace {
+  RemoteSpace({
+    required this.id,
+    required this.name,
+    required this.positionDx,
+    required this.positionDy,
+    required this.sizeWidth,
+    required this.sizeHeight,
+    this.parentId,
+    required this.version,
+    required this.updatedAt,
+    this.isDeleted = false,
+  });
+
+  final String id;
+  final String name;
+  final double positionDx;
+  final double positionDy;
+  final double sizeWidth;
+  final double sizeHeight;
+  final String? parentId;
+  final int version;
+  final DateTime updatedAt;
+  final bool isDeleted;
+
+  JsonMap toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'positionDx': positionDx,
+      'positionDy': positionDy,
+      'sizeWidth': sizeWidth,
+      'sizeHeight': sizeHeight,
+      'parentId': parentId,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'isDeleted': isDeleted,
+    };
+  }
+
+  factory RemoteSpace.fromJson(JsonMap json) {
+    return RemoteSpace(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      positionDx: _toDouble(json['positionDx']),
+      positionDy: _toDouble(json['positionDy']),
+      sizeWidth: _toDouble(json['sizeWidth']),
+      sizeHeight: _toDouble(json['sizeHeight']),
+      parentId: json['parentId'] as String?,
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      isDeleted: json['isDeleted'] as bool? ?? false,
+    );
+  }
+}
+
+class RemoteItem {
+  RemoteItem({
+    required this.id,
+    required this.spaceId,
+    required this.name,
+    required this.description,
+    this.locationSpecification,
+    this.tags,
+    this.imagePath,
+    required this.version,
+    required this.updatedAt,
+    this.isDeleted = false,
+  });
+
+  final String id;
+  final String spaceId;
+  final String name;
+  final String description;
+  final String? locationSpecification;
+  final List<String>? tags;
+  final String? imagePath;
+  final int version;
+  final DateTime updatedAt;
+  final bool isDeleted;
+
+  JsonMap toJson() {
+    return {
+      'id': id,
+      'spaceId': spaceId,
+      'name': name,
+      'description': description,
+      'locationSpecification': locationSpecification,
+      'tags': tags,
+      'imagePath': imagePath,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'isDeleted': isDeleted,
+    };
+  }
+
+  factory RemoteItem.fromJson(JsonMap json) {
+    return RemoteItem(
+      id: json['id'] as String,
+      spaceId: json['spaceId'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String,
+      locationSpecification: json['locationSpecification'] as String?,
+      tags: json['tags'] == null
+          ? null
+          : List<String>.from(json['tags'] as List<dynamic>),
+      imagePath: json['imagePath'] as String?,
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      isDeleted: json['isDeleted'] as bool? ?? false,
+    );
+  }
+}
+
+class RemoteUser {
+  RemoteUser({
+    required this.id,
+    required this.email,
+    this.displayName,
+    this.avatarUrl,
+    required this.isCurrentUser,
+    required this.version,
+    required this.updatedAt,
+    this.isDeleted = false,
+  });
+
+  final String id;
+  final String email;
+  final String? displayName;
+  final String? avatarUrl;
+  final bool isCurrentUser;
+  final int version;
+  final DateTime updatedAt;
+  final bool isDeleted;
+
+  JsonMap toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'displayName': displayName,
+      'avatarUrl': avatarUrl,
+      'isCurrentUser': isCurrentUser,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'isDeleted': isDeleted,
+    };
+  }
+
+  factory RemoteUser.fromJson(JsonMap json) {
+    return RemoteUser(
+      id: json['id'] as String,
+      email: json['email'] as String,
+      displayName: json['displayName'] as String?,
+      avatarUrl: json['avatarUrl'] as String?,
+      isCurrentUser: json['isCurrentUser'] as bool? ?? false,
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      isDeleted: json['isDeleted'] as bool? ?? false,
+    );
+  }
+}
+
+class RemoteMembership {
+  RemoteMembership({
+    required this.spaceId,
+    required this.userId,
+    required this.role,
+    required this.attachmentVisibility,
+    this.joinedAt,
+    required this.version,
+    required this.updatedAt,
+    this.isDeleted = false,
+  });
+
+  final String spaceId;
+  final String userId;
+  final String role;
+  final String attachmentVisibility;
+  final DateTime? joinedAt;
+  final int version;
+  final DateTime updatedAt;
+  final bool isDeleted;
+
+  JsonMap toJson() {
+    return {
+      'spaceId': spaceId,
+      'userId': userId,
+      'role': role,
+      'attachmentVisibility': attachmentVisibility,
+      'joinedAt': joinedAt?.millisecondsSinceEpoch,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'isDeleted': isDeleted,
+    };
+  }
+
+  factory RemoteMembership.fromJson(JsonMap json) {
+    return RemoteMembership(
+      spaceId: json['spaceId'] as String,
+      userId: json['userId'] as String,
+      role: json['role'] as String,
+      attachmentVisibility: json['attachmentVisibility'] as String,
+      joinedAt: json['joinedAt'] == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(json['joinedAt'] as int),
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      isDeleted: json['isDeleted'] as bool? ?? false,
+    );
+  }
+}
+
+class SyncMutation {
+  SyncMutation({
+    required this.entityType,
+    required this.entityId,
+    required this.operation,
+    required this.payload,
+    required this.version,
+    required this.updatedAt,
+    this.spaceId,
+  });
+
+  final String entityType;
+  final String entityId;
+  final String operation;
+  final Map<String, dynamic> payload;
+  final int version;
+  final DateTime updatedAt;
+  final String? spaceId;
+
+  JsonMap toJson() {
+    return {
+      'entityType': entityType,
+      'entityId': entityId,
+      'operation': operation,
+      'payload': payload,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'spaceId': spaceId,
+    };
+  }
+
+  factory SyncMutation.fromJson(JsonMap json) {
+    final payloadDynamic = json['payload'];
+    final payload = payloadDynamic is String
+        ? jsonDecode(payloadDynamic) as Map<String, dynamic>
+        : Map<String, dynamic>.from(payloadDynamic as Map<String, dynamic>);
+    return SyncMutation(
+      entityType: json['entityType'] as String,
+      entityId: json['entityId'] as String,
+      operation: json['operation'] as String,
+      payload: payload,
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      spaceId: json['spaceId'] as String?,
+    );
+  }
+}
+
+class SyncRequest {
+  SyncRequest({
+    required this.mutations,
+    this.cursor,
+  });
+
+  final List<SyncMutation> mutations;
+  final String? cursor;
+
+  JsonMap toJson() {
+    return {
+      'cursor': cursor,
+      'mutations': mutations.map((mutation) => mutation.toJson()).toList(),
+    };
+  }
+
+  factory SyncRequest.fromJson(JsonMap json) {
+    final mutations = (json['mutations'] as List<dynamic>? ?? const [])
+        .map(
+          (dynamic entry) => SyncMutation.fromJson(
+            Map<String, dynamic>.from(entry as Map),
+          ),
+        )
+        .toList();
+    return SyncRequest(
+      mutations: mutations,
+      cursor: json['cursor'] as String?,
+    );
+  }
+}
+
+class SyncResponse {
+  SyncResponse({
+    required this.spaces,
+    required this.items,
+    required this.users,
+    required this.memberships,
+    this.cursor,
+  });
+
+  final List<RemoteSpace> spaces;
+  final List<RemoteItem> items;
+  final List<RemoteUser> users;
+  final List<RemoteMembership> memberships;
+  final String? cursor;
+
+  JsonMap toJson() {
+    return {
+      'cursor': cursor,
+      'spaces': spaces.map((space) => space.toJson()).toList(),
+      'items': items.map((item) => item.toJson()).toList(),
+      'users': users.map((user) => user.toJson()).toList(),
+      'memberships':
+          memberships.map((member) => member.toJson()).toList(),
+    };
+  }
+
+  factory SyncResponse.fromJson(JsonMap json) {
+    List<T> parseList<T>(String key, T Function(JsonMap json) parser) {
+      final value = json[key];
+      if (value is List) {
+        return value
+            .map((entry) => parser(Map<String, dynamic>.from(entry as Map)))
+            .toList();
+      }
+      return const [];
+    }
+
+    return SyncResponse(
+      cursor: json['cursor'] as String?,
+      spaces: parseList('spaces', RemoteSpace.fromJson),
+      items: parseList('items', RemoteItem.fromJson),
+      users: parseList('users', RemoteUser.fromJson),
+      memberships: parseList('memberships', RemoteMembership.fromJson),
+    );
+  }
+
+  factory SyncResponse.empty() {
+    return SyncResponse(
+      spaces: const [],
+      items: const [],
+      users: const [],
+      memberships: const [],
+    );
+  }
+}

--- a/lib/data/remote/remote_api_client.dart
+++ b/lib/data/remote/remote_api_client.dart
@@ -1,0 +1,15 @@
+import 'remote_api_client_base.dart';
+import 'remote_api_client_stub.dart'
+    if (dart.library.io) 'remote_api_client_impl.dart' as factory;
+
+export 'remote_api_client_base.dart';
+
+RemoteApiClient createHttpRemoteApiClient({
+  required String baseUrl,
+  String syncPath = '/sync',
+}) {
+  return factory.createHttpRemoteApiClient(
+    baseUrl: baseUrl,
+    syncPath: syncPath,
+  );
+}

--- a/lib/data/remote/remote_api_client_base.dart
+++ b/lib/data/remote/remote_api_client_base.dart
@@ -1,0 +1,16 @@
+import 'models.dart';
+
+abstract class RemoteApiClient {
+  Future<SyncResponse> sync(SyncRequest request);
+  Future<void> dispose();
+}
+
+class NoopRemoteApiClient implements RemoteApiClient {
+  @override
+  Future<SyncResponse> sync(SyncRequest request) async {
+    return SyncResponse.empty();
+  }
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/lib/data/remote/remote_api_client_impl.dart
+++ b/lib/data/remote/remote_api_client_impl.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'models.dart';
+import 'remote_api_client_base.dart';
+
+RemoteApiClient createHttpRemoteApiClient({
+  required String baseUrl,
+  String syncPath = '/sync',
+}) {
+  return _HttpRemoteApiClient(baseUrl: baseUrl, syncPath: syncPath);
+}
+
+class _HttpRemoteApiClient implements RemoteApiClient {
+  _HttpRemoteApiClient({
+    required this.baseUrl,
+    required this.syncPath,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final String baseUrl;
+  final String syncPath;
+  final HttpClient _httpClient;
+
+  Uri get _syncUri {
+    final base = Uri.parse(baseUrl);
+    final pathUri = Uri.parse(syncPath);
+    return base.resolveUri(pathUri);
+  }
+
+  @override
+  Future<SyncResponse> sync(SyncRequest request) async {
+    final uri = _syncUri;
+    final httpRequest = await _httpClient.postUrl(uri);
+    httpRequest.headers.set(HttpHeaders.contentTypeHeader, 'application/json');
+    httpRequest.add(utf8.encode(jsonEncode(request.toJson())));
+    final response = await httpRequest.close();
+    final responseBody = await utf8.decoder.bind(response).join();
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      if (responseBody.trim().isEmpty) {
+        return SyncResponse.empty();
+      }
+      final dynamic decoded = jsonDecode(responseBody);
+      if (decoded is Map<String, dynamic>) {
+        return SyncResponse.fromJson(decoded);
+      }
+      throw const FormatException('Unexpected sync response payload');
+    }
+    throw HttpException(
+      'Failed to sync (${response.statusCode}): $responseBody',
+      uri: uri,
+    );
+  }
+
+  @override
+  Future<void> dispose() async {
+    _httpClient.close();
+  }
+}

--- a/lib/data/remote/remote_api_client_stub.dart
+++ b/lib/data/remote/remote_api_client_stub.dart
@@ -1,0 +1,8 @@
+import 'remote_api_client_base.dart';
+
+RemoteApiClient createHttpRemoteApiClient({
+  required String baseUrl,
+  String syncPath = '/sync',
+}) {
+  return NoopRemoteApiClient();
+}

--- a/lib/data/spaces_repository.dart
+++ b/lib/data/spaces_repository.dart
@@ -1,0 +1,20 @@
+import '../models/space_model.dart';
+
+import 'local_database.dart';
+
+class SpacesRepository implements SpaceStorage {
+  SpacesRepository({LocalDatabase? database})
+      : _database = database ?? LocalDatabase();
+
+  final LocalDatabase _database;
+
+  @override
+  Future<void> saveSpaces(List<SpaceModel> spaces) {
+    return _database.replaceAllSpaces(spaces);
+  }
+
+  @override
+  Future<List<SpaceModel>> loadSpaces() {
+    return _database.loadSpaces();
+  }
+}

--- a/lib/data/sync_service.dart
+++ b/lib/data/sync_service.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'local_database.dart';
+import 'remote/models.dart';
+import 'remote/remote_api_client.dart';
+
+typedef ConnectivityCheck = Future<bool> Function();
+
+class SyncService {
+  SyncService({
+    required LocalDatabase database,
+    required RemoteApiClient apiClient,
+    Duration pollInterval = const Duration(minutes: 5),
+    int maxBatchSize = 50,
+    ConnectivityCheck? connectivityCheck,
+  })  : _database = database,
+        _apiClient = apiClient,
+        _pollInterval = pollInterval,
+        _maxBatchSize = maxBatchSize,
+        _connectivityCheck = connectivityCheck ?? _alwaysConnected;
+
+  final LocalDatabase _database;
+  final RemoteApiClient _apiClient;
+  final Duration _pollInterval;
+  final int _maxBatchSize;
+  final ConnectivityCheck _connectivityCheck;
+
+  Timer? _timer;
+  bool _isRunning = false;
+  bool _isSyncing = false;
+  String? _cursor;
+
+  static Future<bool> _alwaysConnected() async => true;
+
+  bool get isRunning => _isRunning;
+
+  void start() {
+    if (_isRunning) {
+      return;
+    }
+    _isRunning = true;
+    _timer = Timer.periodic(_pollInterval, (_) {
+      unawaited(syncNow());
+    });
+    unawaited(syncNow());
+  }
+
+  Future<void> syncNow() async {
+    if (_isSyncing) {
+      return;
+    }
+    _isSyncing = true;
+    try {
+      if (!await _connectivityCheck()) {
+        return;
+      }
+      var hasMore = true;
+      while (hasMore) {
+        final pending = await _database.getPendingMutations(
+          limit: _maxBatchSize,
+        );
+        final request = SyncRequest(
+          mutations: pending.map((mutation) => mutation.toSyncMutation()).toList(),
+          cursor: _cursor,
+        );
+        final response = await _apiClient.sync(request);
+        await _database.applyRemoteChanges(response);
+        if (pending.isNotEmpty) {
+          await _database.markMutationsProcessed(
+            pending.map((mutation) => mutation.id).toList(),
+          );
+        }
+        _cursor = response.cursor ?? _cursor;
+        hasMore = pending.length == _maxBatchSize;
+        if (!hasMore) {
+          break;
+        }
+      }
+    } catch (error, stackTrace) {
+      debugPrint('SyncService error: $error\n$stackTrace');
+    } finally {
+      _isSyncing = false;
+    }
+  }
+
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _isRunning = false;
+  }
+
+  Future<void> dispose() async {
+    stop();
+    await _apiClient.dispose();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,23 +2,54 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import 'data/local_database.dart';
+import 'data/remote/remote_api_client.dart';
+import 'data/spaces_repository.dart';
+import 'data/sync_service.dart';
 import 'models/space_model.dart';
 import 'pages/home.dart';
 import 'theme/app_theme.dart';
 import 'theme/theme_controller.dart';
 
-void main() async {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  final database = LocalDatabase();
+  final repository = SpacesRepository(database: database);
+  SpaceModel.configureStorage(repository);
   await SpaceModel.loadItems();
 
+  const syncBaseUrl = String.fromEnvironment(
+    'FIND_IT_SYNC_URL',
+    defaultValue: '',
+  );
+  final RemoteApiClient remoteApiClient = syncBaseUrl.isEmpty
+      ? NoopRemoteApiClient()
+      : createHttpRemoteApiClient(baseUrl: syncBaseUrl);
+
+  final syncService = SyncService(
+    database: database,
+    apiClient: remoteApiClient,
+  );
+
   final themeController = ThemeController();
-  runApp(FindItApp(themeController: themeController));
+  runApp(
+    FindItApp(
+      themeController: themeController,
+      syncService: syncService,
+    ),
+  );
 }
 
 class FindItApp extends StatefulWidget {
-  const FindItApp({super.key, required this.themeController});
+  const FindItApp({
+    super.key,
+    required this.themeController,
+    this.syncService,
+  });
 
   final ThemeController themeController;
+  final SyncService? syncService;
 
   @override
   State<FindItApp> createState() => _FindItAppState();
@@ -29,11 +60,13 @@ class _FindItAppState extends State<FindItApp> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    widget.syncService?.start();
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    widget.syncService?.dispose();
     super.dispose();
   }
 

--- a/lib/models/item_model.dart
+++ b/lib/models/item_model.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
 import 'space_model.dart';
 
 class ItemModel {
+  final String id;
   String name;
   String description;
   String? locationSpecification;
@@ -45,16 +48,18 @@ class ItemModel {
   ];
 
   ItemModel({
+    String? id,
     required this.name,
     required this.description,
     this.locationSpecification,
     this.tags,
     this.imagePath,
     this.parent,
-  });
+  }) : id = id ?? const Uuid().v4();
 
   factory ItemModel.fromJson(Map<String, dynamic> json) {
     return ItemModel(
+      id: json['id'],
       name: json['name'],
       description: json['description'],
       locationSpecification: json['locationSpecification'],
@@ -65,6 +70,7 @@ class ItemModel {
 
   Map<String, dynamic> toJson() {
     return {
+      'id': id,
       'name': name,
       'description': description,
       'locationSpecification': locationSpecification,

--- a/lib/models/space_member.dart
+++ b/lib/models/space_member.dart
@@ -1,0 +1,73 @@
+import 'user_profile.dart';
+
+enum SpaceRole {
+  owner,
+  editor,
+  viewer,
+}
+
+enum AttachmentVisibility {
+  shared,
+  private,
+}
+
+SpaceRole spaceRoleFromName(String value) {
+  return SpaceRole.values.firstWhere(
+    (role) => role.name == value,
+    orElse: () => SpaceRole.viewer,
+  );
+}
+
+AttachmentVisibility attachmentVisibilityFromName(String value) {
+  return AttachmentVisibility.values.firstWhere(
+    (visibility) => visibility.name == value,
+    orElse: () => AttachmentVisibility.shared,
+  );
+}
+
+class SpaceMember {
+  SpaceMember({
+    required this.user,
+    required this.role,
+    this.joinedAt,
+    this.defaultAttachmentVisibility = AttachmentVisibility.shared,
+  });
+
+  final UserProfile user;
+  final SpaceRole role;
+  final DateTime? joinedAt;
+  final AttachmentVisibility defaultAttachmentVisibility;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'user': user.toJson(),
+      'role': role.name,
+      'joinedAt': joinedAt?.toIso8601String(),
+      'attachmentVisibility': defaultAttachmentVisibility.name,
+    };
+  }
+
+  factory SpaceMember.fromJson(Map<String, dynamic> json) {
+    final dynamic userJson = json['user'];
+    final UserProfile user;
+    if (userJson is Map<String, dynamic>) {
+      user = UserProfile.fromJson(userJson);
+    } else {
+      user = UserProfile(
+        id: json['userId'] as String?,
+        email: (json['email'] ?? '') as String,
+      );
+    }
+    return SpaceMember(
+      user: user,
+      role: spaceRoleFromName(json['role'] as String? ?? SpaceRole.viewer.name),
+      joinedAt: json['joinedAt'] is String
+          ? DateTime.tryParse(json['joinedAt'] as String)
+          : null,
+      defaultAttachmentVisibility: attachmentVisibilityFromName(
+        json['attachmentVisibility'] as String? ??
+            AttachmentVisibility.shared.name,
+      ),
+    );
+  }
+}

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,53 @@
+import 'package:uuid/uuid.dart';
+
+class UserProfile {
+  UserProfile({
+    String? id,
+    required this.email,
+    this.displayName,
+    this.avatarUrl,
+    this.isCurrentUser = false,
+  }) : id = id ?? const Uuid().v4();
+
+  final String id;
+  final String email;
+  final String? displayName;
+  final String? avatarUrl;
+  final bool isCurrentUser;
+
+  UserProfile copyWith({
+    String? id,
+    String? email,
+    String? displayName,
+    String? avatarUrl,
+    bool? isCurrentUser,
+  }) {
+    return UserProfile(
+      id: id ?? this.id,
+      email: email ?? this.email,
+      displayName: displayName ?? this.displayName,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      isCurrentUser: isCurrentUser ?? this.isCurrentUser,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'displayName': displayName,
+      'avatarUrl': avatarUrl,
+      'isCurrentUser': isCurrentUser,
+    };
+  }
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    return UserProfile(
+      id: json['id'] as String?,
+      email: json['email'] as String,
+      displayName: json['displayName'] as String?,
+      avatarUrl: json['avatarUrl'] as String?,
+      isCurrentUser: json['isCurrentUser'] as bool? ?? false,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,11 +38,13 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter_svg: ^1.1.6
   path_provider: ^2.1.3
-  build_runner: ^2.1.4
   remove_diacritic: ^0.9.0
   image_picker: ^0.8.4+4
   file_picker: ^5.0.0
   intl: ^0.19.0
+  path: ^1.8.3
+  uuid: ^3.0.7
+  sqflite: ^2.2.8
 
 dev_dependencies:
   flutter_test:
@@ -54,6 +56,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
+  build_runner: ^2.1.4
+  sqflite_common_ffi: ^2.3.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/data/local_database_test.dart
+++ b/test/data/local_database_test.dart
@@ -1,0 +1,195 @@
+import 'dart:io';
+
+import 'package:find_it/data/local_database.dart';
+import 'package:find_it/models/item_model.dart';
+import 'package:find_it/models/space_member.dart';
+import 'package:find_it/models/space_model.dart';
+import 'package:find_it/models/user_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this._documentsPath);
+
+  final String _documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => _documentsPath;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+
+  late Directory tempDir;
+  late PathProviderPlatform originalPlatform;
+  late LocalDatabase database;
+
+  setUp(() async {
+    originalPlatform = PathProviderPlatform.instance;
+    tempDir = await Directory.systemTemp.createTemp('local_database_test');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    database = LocalDatabase(factory: databaseFactoryFfi);
+  });
+
+  tearDown(() async {
+    await database.dispose();
+    PathProviderPlatform.instance = originalPlatform;
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('round-trips spaces and items while restoring parents', () async {
+    final owner = UserProfile(
+      id: 'user-owner',
+      email: 'owner@example.com',
+      displayName: 'Owner',
+      isCurrentUser: true,
+    );
+
+    final viewer = UserProfile(
+      id: 'user-viewer',
+      email: 'viewer@example.com',
+      displayName: 'Viewer',
+    );
+
+    final toolbox = SpaceModel(
+      name: 'Toolbox',
+      position: const Offset(5, 8),
+      size: const Size(60, 40),
+      items: [
+        ItemModel(name: 'Hammer', description: 'Claw hammer'),
+      ],
+      collaborators: [
+        SpaceMember(
+          user: owner,
+          role: SpaceRole.editor,
+          defaultAttachmentVisibility: AttachmentVisibility.private,
+        ),
+      ],
+    );
+
+    final garage = SpaceModel(
+      name: 'Garage',
+      position: const Offset(1, 2),
+      size: const Size(200, 150),
+      mySpaces: [toolbox],
+      items: [
+        ItemModel(name: 'Bike', description: 'Mountain bike'),
+      ],
+      collaborators: [
+        SpaceMember(
+          user: owner,
+          role: SpaceRole.owner,
+          joinedAt: DateTime.utc(2023, 1, 10),
+        ),
+        SpaceMember(
+          user: viewer,
+          role: SpaceRole.viewer,
+          defaultAttachmentVisibility: AttachmentVisibility.private,
+        ),
+      ],
+    );
+
+    await database.replaceAllSpaces([garage]);
+
+    final dbFile = File(p.join(tempDir.path, 'spaces.db'));
+    expect(dbFile.existsSync(), isTrue);
+
+    final loaded = await database.loadSpaces();
+    expect(loaded, hasLength(1));
+
+    final loadedGarage = loaded.single;
+    expect(loadedGarage.name, garage.name);
+    expect(loadedGarage.position, garage.position);
+    expect(loadedGarage.size, garage.size);
+    expect(loadedGarage.items, hasLength(1));
+    expect(loadedGarage.items.single.name, 'Bike');
+    expect(loadedGarage.items.single.parent, same(loadedGarage));
+
+    expect(loadedGarage.collaborators, hasLength(2));
+    final loadedOwner = loadedGarage.collaborators
+        .firstWhere((member) => member.role == SpaceRole.owner);
+    expect(loadedOwner.user.email, owner.email);
+    expect(loadedOwner.user.isCurrentUser, isTrue);
+    expect(loadedOwner.joinedAt?.toUtc(), DateTime.utc(2023, 1, 10));
+    expect(loadedOwner.defaultAttachmentVisibility,
+        AttachmentVisibility.shared);
+
+    final loadedViewer = loadedGarage.collaborators
+        .firstWhere((member) => member.role == SpaceRole.viewer);
+    expect(loadedViewer.user.email, viewer.email);
+    expect(loadedViewer.defaultAttachmentVisibility,
+        AttachmentVisibility.private);
+
+    final loadedToolbox = loadedGarage.mySpaces.single;
+    expect(loadedToolbox.name, toolbox.name);
+    expect(loadedToolbox.parent, same(loadedGarage));
+    expect(loadedToolbox.position, toolbox.position);
+    expect(loadedToolbox.size, toolbox.size);
+    expect(loadedToolbox.items.single.name, 'Hammer');
+    expect(loadedToolbox.items.single.parent, same(loadedToolbox));
+    expect(loadedToolbox.collaborators, hasLength(1));
+    expect(loadedToolbox.collaborators.single.role, SpaceRole.editor);
+    expect(loadedToolbox.collaborators.single.defaultAttachmentVisibility,
+        AttachmentVisibility.private);
+  });
+
+  test('replaceAllSpaces enqueues mutations only when data changes', () async {
+    final owner = UserProfile(
+      id: 'owner',
+      email: 'owner@example.com',
+      isCurrentUser: true,
+    );
+
+    final drawer = SpaceModel(
+      name: 'Drawer',
+      items: [
+        ItemModel(name: 'Keys', description: 'Car keys'),
+      ],
+      collaborators: [
+        SpaceMember(
+          user: owner,
+          role: SpaceRole.owner,
+        ),
+      ],
+    );
+
+    final hallway = SpaceModel(
+      name: 'Hallway',
+      mySpaces: [drawer],
+    );
+    hallway.assignParents();
+
+    await database.replaceAllSpaces([hallway]);
+    final initialMutations = await database.getPendingMutations();
+    expect(initialMutations, isNotEmpty);
+    await database.markMutationsProcessed(
+      initialMutations.map((mutation) => mutation.id).toList(),
+    );
+
+    final unchangedCopy = SpaceModel.fromJson(hallway.toJson());
+    unchangedCopy.assignParents();
+    await database.replaceAllSpaces([unchangedCopy]);
+    final noChangeMutations = await database.getPendingMutations();
+    expect(noChangeMutations, isEmpty);
+
+    final renamed = SpaceModel.fromJson(hallway.toJson());
+    renamed.name = 'Renovated Hallway';
+    renamed.assignParents();
+    await database.replaceAllSpaces([renamed]);
+    final updatedMutations = await database.getPendingMutations();
+    expect(
+      updatedMutations.where((mutation) =>
+          mutation.entityType == 'space' && mutation.operation == 'upsert'),
+      isNotEmpty,
+    );
+    await database.markMutationsProcessed(
+      updatedMutations.map((mutation) => mutation.id).toList(),
+    );
+  });
+}

--- a/test/data/sync_service_test.dart
+++ b/test/data/sync_service_test.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'package:find_it/data/local_database.dart';
+import 'package:find_it/data/remote/models.dart';
+import 'package:find_it/data/remote/remote_api_client.dart';
+import 'package:find_it/data/sync_service.dart';
+import 'package:find_it/models/item_model.dart';
+import 'package:find_it/models/space_member.dart';
+import 'package:find_it/models/space_model.dart';
+import 'package:find_it/models/user_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this._documentsPath);
+
+  final String _documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => _documentsPath;
+}
+
+class FakeRemoteApiClient implements RemoteApiClient {
+  FakeRemoteApiClient({this.handler});
+
+  SyncResponse Function(SyncRequest request)? handler;
+  final List<SyncRequest> capturedRequests = [];
+
+  @override
+  Future<SyncResponse> sync(SyncRequest request) async {
+    capturedRequests.add(request);
+    if (handler != null) {
+      return handler!(request);
+    }
+    return SyncResponse.empty();
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+
+  late Directory tempDir;
+  late PathProviderPlatform originalPlatform;
+  late LocalDatabase database;
+  late FakeRemoteApiClient remoteApiClient;
+  late SyncService syncService;
+
+  setUp(() async {
+    originalPlatform = PathProviderPlatform.instance;
+    tempDir = await Directory.systemTemp.createTemp('sync_service_test');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    database = LocalDatabase(factory: databaseFactoryFfi);
+    remoteApiClient = FakeRemoteApiClient();
+    syncService = SyncService(
+      database: database,
+      apiClient: remoteApiClient,
+      pollInterval: const Duration(minutes: 10),
+    );
+  });
+
+  tearDown(() async {
+    await syncService.dispose();
+    await database.dispose();
+    PathProviderPlatform.instance = originalPlatform;
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('syncNow flushes outbox mutations and applies remote updates', () async {
+    final owner = UserProfile(
+      id: 'owner-user',
+      email: 'owner@example.com',
+      isCurrentUser: true,
+    );
+
+    final closet = SpaceModel(
+      name: 'Closet',
+      items: [
+        ItemModel(name: 'Hat', description: 'Sun hat'),
+      ],
+      collaborators: [
+        SpaceMember(user: owner, role: SpaceRole.owner),
+      ],
+    );
+    closet.assignParents();
+
+    await database.replaceAllSpaces([closet]);
+    final pendingBefore = await database.getPendingMutations();
+    expect(pendingBefore, isNotEmpty);
+
+    final remoteNewItem = RemoteItem(
+      id: 'remote-item-1',
+      spaceId: closet.id,
+      name: 'Scarf',
+      description: 'Wool scarf',
+      version: 1,
+      updatedAt: DateTime.now().toUtc(),
+      isDeleted: false,
+    );
+
+    final remoteSpace = RemoteSpace(
+      id: closet.id,
+      name: closet.name,
+      positionDx: closet.position.dx,
+      positionDy: closet.position.dy,
+      sizeWidth: closet.size.width,
+      sizeHeight: closet.size.height,
+      parentId: null,
+      version: 1,
+      updatedAt: DateTime.now().toUtc(),
+      isDeleted: false,
+    );
+
+    remoteApiClient.handler = (request) {
+      expect(request.mutations, isNotEmpty);
+      return SyncResponse(
+        spaces: [remoteSpace],
+        items: [remoteNewItem],
+        users: const [],
+        memberships: const [],
+        cursor: 'cursor-1',
+      );
+    };
+
+    await syncService.syncNow();
+
+    final pendingAfter = await database.getPendingMutations();
+    expect(pendingAfter, isEmpty);
+
+    final loadedSpaces = await database.loadSpaces();
+    expect(loadedSpaces, hasLength(1));
+    final loadedCloset = loadedSpaces.single;
+    expect(loadedCloset.items, hasLength(2));
+    expect(
+      loadedCloset.items.map((item) => item.name),
+      containsAll(['Hat', 'Scarf']),
+    );
+
+    final dbFile = File(p.join(tempDir.path, 'spaces.db'));
+    expect(dbFile.existsSync(), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- extend the SQLite persistence layer with change detection, an outbox queue, and helpers for replaying remote updates to keep spaces, items, users, and memberships in sync
- add remote sync data models plus an HTTP-capable RemoteApiClient with a no-op fallback and expose a periodic SyncService to flush the outbox and merge server deltas
- wire the sync service into app startup and cover the new persistence and sync flows with sqflite_ffi-backed tests

## Testing
- `flutter test` *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d137b0eebc832a87f99cdcbf9a2ccd