### PR TITLE
refactor: adopt drift for local persistence

### DIFF
--- a/lib/data/local_database.dart
+++ b/lib/data/local_database.dart
@@ -1,0 +1,1229 @@
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/widgets.dart' show Offset, Size;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/item_model.dart';
+import '../models/space_member.dart';
+import '../models/space_model.dart';
+import '../models/user_profile.dart';
+import 'remote/models.dart';
+
+part 'local_database.g.dart';
+
+const _dbName = 'spaces.db';
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final directory = await getApplicationDocumentsDirectory();
+    final file = File(p.join(directory.path, _dbName));
+    return NativeDatabase(file, logStatements: false);
+  });
+}
+
+@DataClassName('SpaceRow')
+class SpacesTable extends Table {
+  @override
+  String get tableName => 'spaces';
+
+  TextColumn get id => text()();
+
+  TextColumn get name => text()();
+
+  RealColumn get positionDx => real().named('position_dx')();
+
+  RealColumn get positionDy => real().named('position_dy')();
+
+  RealColumn get sizeWidth => real().named('size_width')();
+
+  RealColumn get sizeHeight => real().named('size_height')();
+
+  TextColumn get parentId => text()
+      .named('parent_id')
+      .nullable()
+      .customConstraint('NULL REFERENCES spaces(id) ON DELETE CASCADE')();
+
+  IntColumn get updatedAt => integer().named('updated_at')();
+
+  IntColumn get version => integer()();
+
+  BoolColumn get isDeleted =>
+      boolean().named('is_deleted').withDefault(const Constant(false))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('ItemRow')
+class ItemsTable extends Table {
+  @override
+  String get tableName => 'items';
+
+  TextColumn get id => text()();
+
+  TextColumn get spaceId => text()
+      .named('space_id')
+      .customConstraint('REFERENCES spaces(id) ON DELETE CASCADE NOT NULL')();
+
+  TextColumn get name => text()();
+
+  TextColumn get description => text()();
+
+  TextColumn get locationSpecification =>
+      text().named('location_specification').nullable()();
+
+  TextColumn get tagsJson => text().named('tags_json').nullable()();
+
+  TextColumn get imagePath => text().named('image_path').nullable()();
+
+  IntColumn get updatedAt => integer().named('updated_at')();
+
+  IntColumn get version => integer()();
+
+  BoolColumn get isDeleted =>
+      boolean().named('is_deleted').withDefault(const Constant(false))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('UserRow')
+class UsersTable extends Table {
+  @override
+  String get tableName => 'users';
+
+  TextColumn get id => text()();
+
+  TextColumn get email => text()();
+
+  TextColumn get displayName => text().named('display_name').nullable()();
+
+  TextColumn get avatarUrl => text().named('avatar_url').nullable()();
+
+  BoolColumn get isCurrent =>
+      boolean().named('is_current').withDefault(const Constant(false))();
+
+  IntColumn get updatedAt => integer().named('updated_at')();
+
+  IntColumn get version => integer()();
+
+  BoolColumn get isDeleted =>
+      boolean().named('is_deleted').withDefault(const Constant(false))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('MembershipRow')
+class SpaceMembershipsTable extends Table {
+  @override
+  String get tableName => 'space_memberships';
+
+  TextColumn get spaceId => text()
+      .named('space_id')
+      .customConstraint('REFERENCES spaces(id) ON DELETE CASCADE NOT NULL')();
+
+  TextColumn get userId => text()
+      .named('user_id')
+      .customConstraint('REFERENCES users(id) ON DELETE CASCADE NOT NULL')();
+
+  TextColumn get role => text()();
+
+  IntColumn get joinedAt => integer().named('joined_at').nullable()();
+
+  TextColumn get attachmentVisibility =>
+      text().named('attachment_visibility')();
+
+  IntColumn get updatedAt => integer().named('updated_at')();
+
+  IntColumn get version => integer()();
+
+  BoolColumn get isDeleted =>
+      boolean().named('is_deleted').withDefault(const Constant(false))();
+
+  @override
+  Set<Column> get primaryKey => {spaceId, userId};
+}
+
+@DataClassName('OutboxEntryRow')
+class OutboxEntriesTable extends Table {
+  @override
+  String get tableName => 'outbox';
+
+  IntColumn get id => integer().autoIncrement()();
+
+  TextColumn get entityType => text().named('entity_type')();
+
+  TextColumn get entityId => text().named('entity_id')();
+
+  TextColumn get spaceId => text().named('space_id').nullable()();
+
+  TextColumn get operation => text()();
+
+  TextColumn get payload => text()();
+
+  IntColumn get updatedAt => integer().named('updated_at')();
+
+  IntColumn get version => integer()();
+
+  IntColumn get createdAt => integer().named('created_at')();
+}
+
+@DriftDatabase(tables: [
+  SpacesTable,
+  ItemsTable,
+  UsersTable,
+  SpaceMembershipsTable,
+  OutboxEntriesTable,
+])
+class LocalDatabase extends _$LocalDatabase {
+  LocalDatabase({QueryExecutor? executor})
+      : super(executor ?? _openConnection());
+
+  @override
+  int get schemaVersion => 3;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+        onCreate: (Migrator m) async {
+          await m.createAll();
+        },
+        onUpgrade: (Migrator m, int from, int to) async {
+          if (from < 2) {
+            await m.createTable(usersTable);
+            await m.createTable(spaceMembershipsTable);
+          }
+          if (from < 3) {
+            await m.createTable(outboxEntriesTable);
+          }
+        },
+      );
+
+  Future<void> replaceAllSpaces(List<SpaceModel> spaces) async {
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final usersById = <String, UserProfile>{};
+
+    void collectMembers(SpaceModel space) {
+      for (final member in space.collaborators) {
+        usersById[member.user.id] = member.user;
+      }
+      for (final child in space.mySpaces) {
+        collectMembers(child);
+      }
+    }
+
+    for (final root in spaces) {
+      collectMembers(root);
+    }
+
+    await transaction(() async {
+      final existingSpaces = {
+        for (final row in await select(spacesTable).get()) row.id: row,
+      };
+      final existingItems = {
+        for (final row in await select(itemsTable).get()) row.id: row,
+      };
+      final existingUsers = {
+        for (final row in await select(usersTable).get()) row.id: row,
+      };
+      final existingMemberships = {
+        for (final row in await select(spaceMembershipsTable).get())
+          _membershipKey(row.spaceId, row.userId): row,
+      };
+
+      Future<void> upsertUser(UserProfile user) async {
+        final existing = existingUsers.remove(user.id);
+        final shouldRevive = existing?.isDeleted ?? false;
+        final hasChanges = existing == null ||
+            existing.email != user.email ||
+            existing.displayName != user.displayName ||
+            existing.avatarUrl != user.avatarUrl ||
+            existing.isCurrent != user.isCurrentUser;
+        if (existing == null) {
+          const version = 1;
+          await into(usersTable).insert(
+            UsersTableCompanion.insert(
+              id: user.id,
+              email: user.email,
+              displayName: Value(user.displayName),
+              avatarUrl: Value(user.avatarUrl),
+              isCurrent: Value(user.isCurrentUser),
+              updatedAt: timestamp,
+              version: version,
+              isDeleted: const Value(false),
+            ),
+          );
+          await _enqueueMutation(
+            entityType: 'user',
+            entityId: user.id,
+            operation: 'upsert',
+            payload: _userPayload(
+              id: user.id,
+              email: user.email,
+              displayName: user.displayName,
+              avatarUrl: user.avatarUrl,
+              isCurrentUser: user.isCurrentUser,
+              isDeleted: false,
+              updatedAt: timestamp,
+              version: version,
+            ),
+            updatedAt: timestamp,
+            version: version,
+          );
+        } else if (shouldRevive || hasChanges) {
+          final version = existing.version + 1;
+          await (update(usersTable)..where((tbl) => tbl.id.equals(user.id)))
+              .write(
+            UsersTableCompanion(
+              email: Value(user.email),
+              displayName: Value(user.displayName),
+              avatarUrl: Value(user.avatarUrl),
+              isCurrent: Value(user.isCurrentUser),
+              updatedAt: Value(timestamp),
+              version: Value(version),
+              isDeleted: const Value(false),
+            ),
+          );
+          await _enqueueMutation(
+            entityType: 'user',
+            entityId: user.id,
+            operation: 'upsert',
+            payload: _userPayload(
+              id: user.id,
+              email: user.email,
+              displayName: user.displayName,
+              avatarUrl: user.avatarUrl,
+              isCurrentUser: user.isCurrentUser,
+              isDeleted: false,
+              updatedAt: timestamp,
+              version: version,
+            ),
+            updatedAt: timestamp,
+            version: version,
+          );
+        }
+      }
+
+      Future<void> persistSpace(SpaceModel space, String? parentId) async {
+        final existing = existingSpaces.remove(space.id);
+        final shouldRevive = existing?.isDeleted ?? false;
+        final hasChanges = existing == null ||
+            existing.name != space.name ||
+            !_doubleEquals(existing.positionDx, space.position.dx) ||
+            !_doubleEquals(existing.positionDy, space.position.dy) ||
+            !_doubleEquals(existing.sizeWidth, space.size.width) ||
+            !_doubleEquals(existing.sizeHeight, space.size.height) ||
+            existing.parentId != parentId;
+        if (existing == null) {
+          const version = 1;
+          await into(spacesTable).insert(
+            SpacesTableCompanion.insert(
+              id: space.id,
+              name: space.name,
+              positionDx: space.position.dx,
+              positionDy: space.position.dy,
+              sizeWidth: space.size.width,
+              sizeHeight: space.size.height,
+              parentId: Value(parentId),
+              updatedAt: timestamp,
+              version: version,
+              isDeleted: const Value(false),
+            ),
+          );
+          await _enqueueMutation(
+            entityType: 'space',
+            entityId: space.id,
+            operation: 'upsert',
+            payload: _spacePayload(
+              spaceId: space.id,
+              name: space.name,
+              position: space.position,
+              size: space.size,
+              parentId: parentId,
+              isDeleted: false,
+              updatedAt: timestamp,
+              version: version,
+            ),
+            updatedAt: timestamp,
+            version: version,
+            spaceId: space.id,
+          );
+        } else if (shouldRevive || hasChanges) {
+          final version = existing.version + 1;
+          await (update(spacesTable)..where((tbl) => tbl.id.equals(space.id)))
+              .write(
+            SpacesTableCompanion(
+              name: Value(space.name),
+              positionDx: Value(space.position.dx),
+              positionDy: Value(space.position.dy),
+              sizeWidth: Value(space.size.width),
+              sizeHeight: Value(space.size.height),
+              parentId: Value(parentId),
+              updatedAt: Value(timestamp),
+              version: Value(version),
+              isDeleted: const Value(false),
+            ),
+          );
+          await _enqueueMutation(
+            entityType: 'space',
+            entityId: space.id,
+            operation: 'upsert',
+            payload: _spacePayload(
+              spaceId: space.id,
+              name: space.name,
+              position: space.position,
+              size: space.size,
+              parentId: parentId,
+              isDeleted: false,
+              updatedAt: timestamp,
+              version: version,
+            ),
+            updatedAt: timestamp,
+            version: version,
+            spaceId: space.id,
+          );
+        }
+
+        final itemIdsForSpace = <String>{};
+        for (final item in space.items) {
+          final existingItem = existingItems.remove(item.id);
+          final tagsJson = item.tags == null
+              ? null
+              : jsonEncode(List<String>.from(item.tags!));
+          final shouldReviveItem = existingItem?.isDeleted ?? false;
+          final itemChanged = existingItem == null ||
+              existingItem.spaceId != space.id ||
+              existingItem.name != item.name ||
+              existingItem.description != item.description ||
+              existingItem.locationSpecification !=
+                  item.locationSpecification ||
+              existingItem.tagsJson != tagsJson ||
+              existingItem.imagePath != item.imagePath;
+          itemIdsForSpace.add(item.id);
+          if (existingItem == null) {
+            const version = 1;
+            await into(itemsTable).insert(
+              ItemsTableCompanion.insert(
+                id: item.id,
+                spaceId: space.id,
+                name: item.name,
+                description: item.description,
+                locationSpecification: Value(item.locationSpecification),
+                tagsJson: Value(tagsJson),
+                imagePath: Value(item.imagePath),
+                updatedAt: timestamp,
+                version: version,
+                isDeleted: const Value(false),
+              ),
+            );
+            await _enqueueMutation(
+              entityType: 'item',
+              entityId: item.id,
+              operation: 'upsert',
+              payload: _itemPayload(
+                id: item.id,
+                spaceId: space.id,
+                name: item.name,
+                description: item.description,
+                locationSpecification: item.locationSpecification,
+                tags: item.tags,
+                imagePath: item.imagePath,
+                isDeleted: false,
+                updatedAt: timestamp,
+                version: version,
+              ),
+              updatedAt: timestamp,
+              version: version,
+              spaceId: space.id,
+            );
+          } else if (shouldReviveItem || itemChanged) {
+            final version = existingItem.version + 1;
+            await (update(itemsTable)..where((tbl) => tbl.id.equals(item.id)))
+                .write(
+              ItemsTableCompanion(
+                spaceId: Value(space.id),
+                name: Value(item.name),
+                description: Value(item.description),
+                locationSpecification: Value(item.locationSpecification),
+                tagsJson: Value(tagsJson),
+                imagePath: Value(item.imagePath),
+                updatedAt: Value(timestamp),
+                version: Value(version),
+                isDeleted: const Value(false),
+              ),
+            );
+            await _enqueueMutation(
+              entityType: 'item',
+              entityId: item.id,
+              operation: 'upsert',
+              payload: _itemPayload(
+                id: item.id,
+                spaceId: space.id,
+                name: item.name,
+                description: item.description,
+                locationSpecification: item.locationSpecification,
+                tags: item.tags,
+                imagePath: item.imagePath,
+                isDeleted: false,
+                updatedAt: timestamp,
+                version: version,
+              ),
+              updatedAt: timestamp,
+              version: version,
+              spaceId: space.id,
+            );
+          }
+        }
+
+        for (final entry in existingItems.entries.toList()) {
+          final row = entry.value;
+          if (row.spaceId != space.id || itemIdsForSpace.contains(entry.key)) {
+            continue;
+          }
+          if (row.isDeleted) {
+            existingItems.remove(entry.key);
+            continue;
+          }
+          final version = row.version + 1;
+          await (update(itemsTable)..where((tbl) => tbl.id.equals(entry.key)))
+              .write(
+            ItemsTableCompanion(
+              isDeleted: const Value(true),
+              updatedAt: Value(timestamp),
+              version: Value(version),
+            ),
+          );
+          await _enqueueMutation(
+            entityType: 'item',
+            entityId: entry.key,
+            operation: 'delete',
+            payload: {
+              'id': entry.key,
+              'spaceId': row.spaceId,
+              'isDeleted': true,
+              'updatedAt': timestamp,
+              'version': version,
+            },
+            updatedAt: timestamp,
+            version: version,
+            spaceId: row.spaceId,
+          );
+          existingItems.remove(entry.key);
+        }
+
+        final membershipKeys = <String>{};
+        for (final member in space.collaborators) {
+          final key = _membershipKey(space.id, member.user.id);
+          membershipKeys.add(key);
+          final existingMembership = existingMemberships.remove(key);
+          final shouldReviveMembership = existingMembership?.isDeleted ?? false;
+          final joinedAt = member.joinedAt?.millisecondsSinceEpoch;
+          final membershipChanged = existingMembership == null ||
+              existingMembership.role != member.role.name ||
+              existingMembership.joinedAt != joinedAt ||
+              existingMembership.attachmentVisibility !=
+                  member.defaultAttachmentVisibility.name;
+          if (existingMembership == null) {
+            const version = 1;
+            await into(spaceMembershipsTable).insert(
+              SpaceMembershipsTableCompanion.insert(
+                spaceId: space.id,
+                userId: member.user.id,
+                role: member.role.name,
+                joinedAt: Value(joinedAt),
+                attachmentVisibility: member.defaultAttachmentVisibility.name,
+                updatedAt: timestamp,
+                version: version,
+                isDeleted: const Value(false),
+              ),
+            );
+            await _enqueueMutation(
+              entityType: 'space_membership',
+              entityId: key,
+              operation: 'upsert',
+              payload: _membershipPayload(
+                spaceId: space.id,
+                userId: member.user.id,
+                role: member.role.name,
+                attachmentVisibility: member.defaultAttachmentVisibility.name,
+                joinedAt: member.joinedAt,
+                isDeleted: false,
+                updatedAt: timestamp,
+                version: version,
+              ),
+              updatedAt: timestamp,
+              version: version,
+              spaceId: space.id,
+            );
+          } else if (shouldReviveMembership || membershipChanged) {
+            final version = existingMembership.version + 1;
+            await (update(spaceMembershipsTable)
+                  ..where((tbl) =>
+                      tbl.spaceId.equals(space.id) &
+                      tbl.userId.equals(member.user.id)))
+                .write(
+              SpaceMembershipsTableCompanion(
+                role: Value(member.role.name),
+                joinedAt: Value(joinedAt),
+                attachmentVisibility:
+                    Value(member.defaultAttachmentVisibility.name),
+                updatedAt: Value(timestamp),
+                version: Value(version),
+                isDeleted: const Value(false),
+              ),
+            );
+            await _enqueueMutation(
+              entityType: 'space_membership',
+              entityId: key,
+              operation: 'upsert',
+              payload: _membershipPayload(
+                spaceId: space.id,
+                userId: member.user.id,
+                role: member.role.name,
+                attachmentVisibility: member.defaultAttachmentVisibility.name,
+                joinedAt: member.joinedAt,
+                isDeleted: false,
+                updatedAt: timestamp,
+                version: version,
+              ),
+              updatedAt: timestamp,
+              version: version,
+              spaceId: space.id,
+            );
+          }
+        }
+
+        for (final entry in existingMemberships.entries.toList()) {
+          final row = entry.value;
+          if (row.spaceId != space.id || membershipKeys.contains(entry.key)) {
+            continue;
+          }
+          if (row.isDeleted) {
+            existingMemberships.remove(entry.key);
+            continue;
+          }
+          final version = row.version + 1;
+          await (update(spaceMembershipsTable)
+                ..where((tbl) =>
+                    tbl.spaceId.equals(row.spaceId) &
+                    tbl.userId.equals(row.userId)))
+              .write(
+            SpaceMembershipsTableCompanion(
+              isDeleted: const Value(true),
+              updatedAt: Value(timestamp),
+              version: Value(version),
+            ),
+          );
+          await _enqueueMutation(
+            entityType: 'space_membership',
+            entityId: entry.key,
+            operation: 'delete',
+            payload: {
+              'spaceId': row.spaceId,
+              'userId': row.userId,
+              'isDeleted': true,
+              'updatedAt': timestamp,
+              'version': version,
+            },
+            updatedAt: timestamp,
+            version: version,
+            spaceId: row.spaceId,
+          );
+          existingMemberships.remove(entry.key);
+        }
+
+        for (final child in space.mySpaces) {
+          await persistSpace(child, space.id);
+        }
+      }
+
+      for (final user in usersById.values) {
+        await upsertUser(user);
+      }
+
+      for (final root in spaces) {
+        await persistSpace(root, null);
+      }
+
+      for (final entry in existingSpaces.entries) {
+        final row = entry.value;
+        if (row.isDeleted) {
+          continue;
+        }
+        final version = row.version + 1;
+        await (update(spacesTable)..where((tbl) => tbl.id.equals(row.id)))
+            .write(
+          SpacesTableCompanion(
+            isDeleted: const Value(true),
+            updatedAt: Value(timestamp),
+            version: Value(version),
+          ),
+        );
+        await _enqueueMutation(
+          entityType: 'space',
+          entityId: row.id,
+          operation: 'delete',
+          payload: {
+            'id': row.id,
+            'isDeleted': true,
+            'updatedAt': timestamp,
+            'version': version,
+          },
+          updatedAt: timestamp,
+          version: version,
+          spaceId: row.id,
+        );
+      }
+
+      for (final entry in existingItems.entries) {
+        final row = entry.value;
+        if (row.isDeleted) {
+          continue;
+        }
+        final version = row.version + 1;
+        await (update(itemsTable)..where((tbl) => tbl.id.equals(row.id))).write(
+          ItemsTableCompanion(
+            isDeleted: const Value(true),
+            updatedAt: Value(timestamp),
+            version: Value(version),
+          ),
+        );
+        await _enqueueMutation(
+          entityType: 'item',
+          entityId: row.id,
+          operation: 'delete',
+          payload: {
+            'id': row.id,
+            'spaceId': row.spaceId,
+            'isDeleted': true,
+            'updatedAt': timestamp,
+            'version': version,
+          },
+          updatedAt: timestamp,
+          version: version,
+          spaceId: row.spaceId,
+        );
+      }
+
+      for (final entry in existingMemberships.entries) {
+        final row = entry.value;
+        if (row.isDeleted) {
+          continue;
+        }
+        final version = row.version + 1;
+        await (update(spaceMembershipsTable)
+              ..where((tbl) =>
+                  tbl.spaceId.equals(row.spaceId) &
+                  tbl.userId.equals(row.userId)))
+            .write(
+          SpaceMembershipsTableCompanion(
+            isDeleted: const Value(true),
+            updatedAt: Value(timestamp),
+            version: Value(version),
+          ),
+        );
+        await _enqueueMutation(
+          entityType: 'space_membership',
+          entityId: _membershipKey(row.spaceId, row.userId),
+          operation: 'delete',
+          payload: {
+            'spaceId': row.spaceId,
+            'userId': row.userId,
+            'isDeleted': true,
+            'updatedAt': timestamp,
+            'version': version,
+          },
+          updatedAt: timestamp,
+          version: version,
+          spaceId: row.spaceId,
+        );
+      }
+
+      for (final entry in existingUsers.entries) {
+        final row = entry.value;
+        if (row.isDeleted || row.isCurrent) {
+          continue;
+        }
+        final version = row.version + 1;
+        await (update(usersTable)..where((tbl) => tbl.id.equals(row.id))).write(
+          UsersTableCompanion(
+            isDeleted: const Value(true),
+            updatedAt: Value(timestamp),
+            version: Value(version),
+          ),
+        );
+        await _enqueueMutation(
+          entityType: 'user',
+          entityId: row.id,
+          operation: 'delete',
+          payload: {
+            'id': row.id,
+            'isDeleted': true,
+            'updatedAt': timestamp,
+            'version': version,
+          },
+          updatedAt: timestamp,
+          version: version,
+        );
+      }
+    });
+  }
+
+  Future<List<SpaceModel>> loadSpaces() async {
+    final spaceRows = await (select(spacesTable)
+          ..where((tbl) => tbl.isDeleted.equals(false)))
+        .get();
+    if (spaceRows.isEmpty) {
+      return [];
+    }
+
+    final itemRows = await (select(itemsTable)
+          ..where((tbl) => tbl.isDeleted.equals(false)))
+        .get();
+    final userRows = await (select(usersTable)
+          ..where((tbl) => tbl.isDeleted.equals(false)))
+        .get();
+    final membershipRows = await (select(spaceMembershipsTable)
+          ..where((tbl) => tbl.isDeleted.equals(false)))
+        .get();
+
+    final spacesById = <String, SpaceModel>{};
+    for (final row in spaceRows) {
+      spacesById[row.id] = SpaceModel(
+        id: row.id,
+        name: row.name,
+        position: Offset(row.positionDx, row.positionDy),
+        size: Size(row.sizeWidth, row.sizeHeight),
+        mySpaces: const [],
+        items: const [],
+      );
+    }
+
+    for (final row in spaceRows) {
+      final parentId = row.parentId;
+      if (parentId == null) {
+        continue;
+      }
+      final space = spacesById[row.id];
+      final parent = spacesById[parentId];
+      if (space != null && parent != null) {
+        space.parent = parent;
+        parent.mySpaces.add(space);
+      }
+    }
+
+    for (final row in itemRows) {
+      final space = spacesById[row.spaceId];
+      if (space == null) {
+        continue;
+      }
+      final tags = row.tagsJson == null
+          ? null
+          : List<String>.from(jsonDecode(row.tagsJson!) as List<dynamic>);
+      final item = ItemModel(
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        locationSpecification: row.locationSpecification,
+        tags: tags,
+        imagePath: row.imagePath,
+        parent: space,
+      );
+      space.items.add(item);
+    }
+
+    final usersById = <String, UserProfile>{};
+    for (final row in userRows) {
+      usersById[row.id] = UserProfile(
+        id: row.id,
+        email: row.email,
+        displayName: row.displayName,
+        avatarUrl: row.avatarUrl,
+        isCurrentUser: row.isCurrent,
+      );
+    }
+
+    for (final row in membershipRows) {
+      final space = spacesById[row.spaceId];
+      final user = usersById[row.userId];
+      if (space == null || user == null) {
+        continue;
+      }
+      space.collaborators.add(
+        SpaceMember(
+          user: user,
+          role: spaceRoleFromName(row.role),
+          joinedAt: row.joinedAt == null
+              ? null
+              : DateTime.fromMillisecondsSinceEpoch(row.joinedAt!),
+          defaultAttachmentVisibility:
+              attachmentVisibilityFromName(row.attachmentVisibility),
+        ),
+      );
+    }
+
+    final roots =
+        spacesById.values.where((space) => space.parent == null).toList();
+    for (final space in roots) {
+      space.assignParents();
+    }
+    return roots;
+  }
+
+  Future<List<PendingMutation>> getPendingMutations({int limit = 50}) async {
+    final rows = await (select(outboxEntriesTable)
+          ..orderBy([(tbl) => OrderingTerm(expression: tbl.id)])
+          ..limit(limit))
+        .get();
+    return rows
+        .map(
+          (row) => PendingMutation(
+            id: row.id,
+            entityType: row.entityType,
+            entityId: row.entityId,
+            spaceId: row.spaceId,
+            operation: row.operation,
+            payload: Map<String, dynamic>.from(
+              jsonDecode(row.payload) as Map<String, dynamic>,
+            ),
+            updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+            version: row.version,
+          ),
+        )
+        .toList();
+  }
+
+  Future<void> markMutationsProcessed(List<int> ids) async {
+    if (ids.isEmpty) {
+      return;
+    }
+    await (delete(outboxEntriesTable)..where((tbl) => tbl.id.isIn(ids))).go();
+  }
+
+  Future<void> applyRemoteChanges(SyncResponse response) async {
+    await transaction(() async {
+      await _applyRemoteUsers(response.users);
+      await _applyRemoteSpaces(response.spaces);
+      await _applyRemoteItems(response.items);
+      await _applyRemoteMemberships(response.memberships);
+    });
+  }
+
+  Future<void> _applyRemoteUsers(List<RemoteUser> users) async {
+    for (final user in users) {
+      final existing = await (select(usersTable)
+            ..where((tbl) => tbl.id.equals(user.id)))
+          .getSingleOrNull();
+      final localVersion = existing?.version ?? 0;
+      final localUpdatedAt = existing?.updatedAt ?? 0;
+      final remoteUpdatedAt = user.updatedAt.millisecondsSinceEpoch;
+      if (localVersion > user.version) {
+        continue;
+      }
+      if (localVersion == user.version && localUpdatedAt >= remoteUpdatedAt) {
+        continue;
+      }
+      final data = UsersTableCompanion(
+        email: Value(user.email),
+        displayName: Value(user.displayName),
+        avatarUrl: Value(user.avatarUrl),
+        isCurrent: Value(user.isCurrentUser),
+        isDeleted: Value(user.isDeleted),
+        updatedAt: Value(remoteUpdatedAt),
+        version: Value(user.version),
+      );
+      if (existing == null) {
+        await into(usersTable).insert(
+          data.copyWith(id: Value(user.id)),
+          mode: InsertMode.insertOrReplace,
+        );
+      } else {
+        await (update(usersTable)..where((tbl) => tbl.id.equals(user.id)))
+            .write(data);
+      }
+    }
+  }
+
+  Future<void> _applyRemoteSpaces(List<RemoteSpace> spaces) async {
+    for (final space in spaces) {
+      final existing = await (select(spacesTable)
+            ..where((tbl) => tbl.id.equals(space.id)))
+          .getSingleOrNull();
+      final localVersion = existing?.version ?? 0;
+      final localUpdatedAt = existing?.updatedAt ?? 0;
+      final remoteUpdatedAt = space.updatedAt.millisecondsSinceEpoch;
+      if (localVersion > space.version) {
+        continue;
+      }
+      if (localVersion == space.version && localUpdatedAt >= remoteUpdatedAt) {
+        continue;
+      }
+      final data = SpacesTableCompanion(
+        name: Value(space.name),
+        positionDx: Value(space.positionDx),
+        positionDy: Value(space.positionDy),
+        sizeWidth: Value(space.sizeWidth),
+        sizeHeight: Value(space.sizeHeight),
+        parentId: Value(space.parentId),
+        isDeleted: Value(space.isDeleted),
+        updatedAt: Value(remoteUpdatedAt),
+        version: Value(space.version),
+      );
+      if (existing == null) {
+        await into(spacesTable).insert(
+          data.copyWith(id: Value(space.id)),
+          mode: InsertMode.insertOrReplace,
+        );
+      } else {
+        await (update(spacesTable)..where((tbl) => tbl.id.equals(space.id)))
+            .write(data);
+      }
+    }
+  }
+
+  Future<void> _applyRemoteItems(List<RemoteItem> items) async {
+    for (final item in items) {
+      final existing = await (select(itemsTable)
+            ..where((tbl) => tbl.id.equals(item.id)))
+          .getSingleOrNull();
+      final localVersion = existing?.version ?? 0;
+      final localUpdatedAt = existing?.updatedAt ?? 0;
+      final remoteUpdatedAt = item.updatedAt.millisecondsSinceEpoch;
+      if (localVersion > item.version) {
+        continue;
+      }
+      if (localVersion == item.version && localUpdatedAt >= remoteUpdatedAt) {
+        continue;
+      }
+      final data = ItemsTableCompanion(
+        spaceId: Value(item.spaceId),
+        name: Value(item.name),
+        description: Value(item.description),
+        locationSpecification: Value(item.locationSpecification),
+        tagsJson: Value(item.tags == null ? null : jsonEncode(item.tags)),
+        imagePath: Value(item.imagePath),
+        isDeleted: Value(item.isDeleted),
+        updatedAt: Value(remoteUpdatedAt),
+        version: Value(item.version),
+      );
+      if (existing == null) {
+        await into(itemsTable).insert(
+          data.copyWith(id: Value(item.id)),
+          mode: InsertMode.insertOrReplace,
+        );
+      } else {
+        await (update(itemsTable)..where((tbl) => tbl.id.equals(item.id)))
+            .write(data);
+      }
+    }
+  }
+
+  Future<void> _applyRemoteMemberships(
+      List<RemoteMembership> memberships) async {
+    for (final membership in memberships) {
+      final existing = await (select(spaceMembershipsTable)
+            ..where((tbl) =>
+                tbl.spaceId.equals(membership.spaceId) &
+                tbl.userId.equals(membership.userId)))
+          .getSingleOrNull();
+      final localVersion = existing?.version ?? 0;
+      final localUpdatedAt = existing?.updatedAt ?? 0;
+      final remoteUpdatedAt = membership.updatedAt.millisecondsSinceEpoch;
+      if (localVersion > membership.version) {
+        continue;
+      }
+      if (localVersion == membership.version &&
+          localUpdatedAt >= remoteUpdatedAt) {
+        continue;
+      }
+      final data = SpaceMembershipsTableCompanion(
+        role: Value(membership.role),
+        joinedAt: Value(membership.joinedAt?.millisecondsSinceEpoch),
+        attachmentVisibility: Value(membership.attachmentVisibility),
+        isDeleted: Value(membership.isDeleted),
+        updatedAt: Value(remoteUpdatedAt),
+        version: Value(membership.version),
+      );
+      if (existing == null) {
+        await into(spaceMembershipsTable).insert(
+          data.copyWith(
+            spaceId: Value(membership.spaceId),
+            userId: Value(membership.userId),
+          ),
+          mode: InsertMode.insertOrReplace,
+        );
+      } else {
+        await (update(spaceMembershipsTable)
+              ..where((tbl) =>
+                  tbl.spaceId.equals(membership.spaceId) &
+                  tbl.userId.equals(membership.userId)))
+            .write(data);
+      }
+    }
+  }
+
+  Future<void> dispose() async {
+    await close();
+  }
+
+  Future<void> _enqueueMutation({
+    required String entityType,
+    required String entityId,
+    String? spaceId,
+    required String operation,
+    required Map<String, dynamic> payload,
+    required int updatedAt,
+    required int version,
+  }) async {
+    await into(outboxEntriesTable).insert(
+      OutboxEntriesTableCompanion.insert(
+        entityType: entityType,
+        entityId: entityId,
+        spaceId: Value(spaceId),
+        operation: operation,
+        payload: jsonEncode(payload),
+        updatedAt: updatedAt,
+        version: version,
+        createdAt: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+}
+
+String _membershipKey(String spaceId, String userId) => '$spaceId|$userId';
+
+bool _doubleEquals(double a, double b) => (a - b).abs() < 0.000001;
+
+Map<String, dynamic> _spacePayload({
+  required String spaceId,
+  required String name,
+  required Offset position,
+  required Size size,
+  String? parentId,
+  required bool isDeleted,
+  required int updatedAt,
+  required int version,
+}) {
+  return {
+    'id': spaceId,
+    'name': name,
+    'positionDx': position.dx,
+    'positionDy': position.dy,
+    'sizeWidth': size.width,
+    'sizeHeight': size.height,
+    'parentId': parentId,
+    'isDeleted': isDeleted,
+    'updatedAt': updatedAt,
+    'version': version,
+  };
+}
+
+Map<String, dynamic> _itemPayload({
+  required String id,
+  required String spaceId,
+  required String name,
+  required String description,
+  String? locationSpecification,
+  List<String>? tags,
+  String? imagePath,
+  required bool isDeleted,
+  required int updatedAt,
+  required int version,
+}) {
+  return {
+    'id': id,
+    'spaceId': spaceId,
+    'name': name,
+    'description': description,
+    'locationSpecification': locationSpecification,
+    'tags': tags,
+    'imagePath': imagePath,
+    'isDeleted': isDeleted,
+    'updatedAt': updatedAt,
+    'version': version,
+  };
+}
+
+Map<String, dynamic> _membershipPayload({
+  required String spaceId,
+  required String userId,
+  required String role,
+  required String attachmentVisibility,
+  DateTime? joinedAt,
+  required bool isDeleted,
+  required int updatedAt,
+  required int version,
+}) {
+  return {
+    'spaceId': spaceId,
+    'userId': userId,
+    'role': role,
+    'attachmentVisibility': attachmentVisibility,
+    'joinedAt': joinedAt?.millisecondsSinceEpoch,
+    'isDeleted': isDeleted,
+    'updatedAt': updatedAt,
+    'version': version,
+  };
+}
+
+Map<String, dynamic> _userPayload({
+  required String id,
+  required String email,
+  String? displayName,
+  String? avatarUrl,
+  required bool isCurrentUser,
+  required bool isDeleted,
+  required int updatedAt,
+  required int version,
+}) {
+  return {
+    'id': id,
+    'email': email,
+    'displayName': displayName,
+    'avatarUrl': avatarUrl,
+    'isCurrentUser': isCurrentUser,
+    'isDeleted': isDeleted,
+    'updatedAt': updatedAt,
+    'version': version,
+  };
+}
+
+class PendingMutation {
+  PendingMutation({
+    required this.id,
+    required this.entityType,
+    required this.entityId,
+    required this.operation,
+    required this.payload,
+    required this.updatedAt,
+    required this.version,
+    this.spaceId,
+  });
+
+  final int id;
+  final String entityType;
+  final String entityId;
+  final String operation;
+  final Map<String, dynamic> payload;
+  final DateTime updatedAt;
+  final int version;
+  final String? spaceId;
+
+  SyncMutation toSyncMutation() {
+    return SyncMutation(
+      entityType: entityType,
+      entityId: entityId,
+      operation: operation,
+      payload: payload,
+      version: version,
+      updatedAt: updatedAt,
+      spaceId: spaceId,
+    );
+  }
+}

--- a/lib/data/local_database.g.dart
+++ b/lib/data/local_database.g.dart
@@ -1,0 +1,3498 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'local_database.dart';
+
+// ignore_for_file: type=lint
+class $SpacesTableTable extends SpacesTable
+    with TableInfo<$SpacesTableTable, SpaceRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $SpacesTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+      'id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _positionDxMeta =
+      const VerificationMeta('positionDx');
+  @override
+  late final GeneratedColumn<double> positionDx = GeneratedColumn<double>(
+      'position_dx', aliasedName, false,
+      type: DriftSqlType.double, requiredDuringInsert: true);
+  static const VerificationMeta _positionDyMeta =
+      const VerificationMeta('positionDy');
+  @override
+  late final GeneratedColumn<double> positionDy = GeneratedColumn<double>(
+      'position_dy', aliasedName, false,
+      type: DriftSqlType.double, requiredDuringInsert: true);
+  static const VerificationMeta _sizeWidthMeta =
+      const VerificationMeta('sizeWidth');
+  @override
+  late final GeneratedColumn<double> sizeWidth = GeneratedColumn<double>(
+      'size_width', aliasedName, false,
+      type: DriftSqlType.double, requiredDuringInsert: true);
+  static const VerificationMeta _sizeHeightMeta =
+      const VerificationMeta('sizeHeight');
+  @override
+  late final GeneratedColumn<double> sizeHeight = GeneratedColumn<double>(
+      'size_height', aliasedName, false,
+      type: DriftSqlType.double, requiredDuringInsert: true);
+  static const VerificationMeta _parentIdMeta =
+      const VerificationMeta('parentId');
+  @override
+  late final GeneratedColumn<String> parentId = GeneratedColumn<String>(
+      'parent_id', aliasedName, true,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      $customConstraints: 'NULL REFERENCES spaces(id) ON DELETE CASCADE');
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _versionMeta =
+      const VerificationMeta('version');
+  @override
+  late final GeneratedColumn<int> version = GeneratedColumn<int>(
+      'version', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _isDeletedMeta =
+      const VerificationMeta('isDeleted');
+  @override
+  late final GeneratedColumn<bool> isDeleted = GeneratedColumn<bool>(
+      'is_deleted', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_deleted" IN (0, 1))'),
+      defaultValue: const Constant(false));
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        name,
+        positionDx,
+        positionDy,
+        sizeWidth,
+        sizeHeight,
+        parentId,
+        updatedAt,
+        version,
+        isDeleted
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'spaces';
+  @override
+  VerificationContext validateIntegrity(Insertable<SpaceRow> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('position_dx')) {
+      context.handle(
+          _positionDxMeta,
+          positionDx.isAcceptableOrUnknown(
+              data['position_dx']!, _positionDxMeta));
+    } else if (isInserting) {
+      context.missing(_positionDxMeta);
+    }
+    if (data.containsKey('position_dy')) {
+      context.handle(
+          _positionDyMeta,
+          positionDy.isAcceptableOrUnknown(
+              data['position_dy']!, _positionDyMeta));
+    } else if (isInserting) {
+      context.missing(_positionDyMeta);
+    }
+    if (data.containsKey('size_width')) {
+      context.handle(_sizeWidthMeta,
+          sizeWidth.isAcceptableOrUnknown(data['size_width']!, _sizeWidthMeta));
+    } else if (isInserting) {
+      context.missing(_sizeWidthMeta);
+    }
+    if (data.containsKey('size_height')) {
+      context.handle(
+          _sizeHeightMeta,
+          sizeHeight.isAcceptableOrUnknown(
+              data['size_height']!, _sizeHeightMeta));
+    } else if (isInserting) {
+      context.missing(_sizeHeightMeta);
+    }
+    if (data.containsKey('parent_id')) {
+      context.handle(_parentIdMeta,
+          parentId.isAcceptableOrUnknown(data['parent_id']!, _parentIdMeta));
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('version')) {
+      context.handle(_versionMeta,
+          version.isAcceptableOrUnknown(data['version']!, _versionMeta));
+    } else if (isInserting) {
+      context.missing(_versionMeta);
+    }
+    if (data.containsKey('is_deleted')) {
+      context.handle(_isDeletedMeta,
+          isDeleted.isAcceptableOrUnknown(data['is_deleted']!, _isDeletedMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  SpaceRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return SpaceRow(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      positionDx: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}position_dx'])!,
+      positionDy: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}position_dy'])!,
+      sizeWidth: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}size_width'])!,
+      sizeHeight: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}size_height'])!,
+      parentId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}parent_id']),
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      version: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}version'])!,
+      isDeleted: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_deleted'])!,
+    );
+  }
+
+  @override
+  $SpacesTableTable createAlias(String alias) {
+    return $SpacesTableTable(attachedDatabase, alias);
+  }
+}
+
+class SpaceRow extends DataClass implements Insertable<SpaceRow> {
+  final String id;
+  final String name;
+  final double positionDx;
+  final double positionDy;
+  final double sizeWidth;
+  final double sizeHeight;
+  final String? parentId;
+  final int updatedAt;
+  final int version;
+  final bool isDeleted;
+  const SpaceRow(
+      {required this.id,
+      required this.name,
+      required this.positionDx,
+      required this.positionDy,
+      required this.sizeWidth,
+      required this.sizeHeight,
+      this.parentId,
+      required this.updatedAt,
+      required this.version,
+      required this.isDeleted});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['name'] = Variable<String>(name);
+    map['position_dx'] = Variable<double>(positionDx);
+    map['position_dy'] = Variable<double>(positionDy);
+    map['size_width'] = Variable<double>(sizeWidth);
+    map['size_height'] = Variable<double>(sizeHeight);
+    if (!nullToAbsent || parentId != null) {
+      map['parent_id'] = Variable<String>(parentId);
+    }
+    map['updated_at'] = Variable<int>(updatedAt);
+    map['version'] = Variable<int>(version);
+    map['is_deleted'] = Variable<bool>(isDeleted);
+    return map;
+  }
+
+  SpacesTableCompanion toCompanion(bool nullToAbsent) {
+    return SpacesTableCompanion(
+      id: Value(id),
+      name: Value(name),
+      positionDx: Value(positionDx),
+      positionDy: Value(positionDy),
+      sizeWidth: Value(sizeWidth),
+      sizeHeight: Value(sizeHeight),
+      parentId: parentId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(parentId),
+      updatedAt: Value(updatedAt),
+      version: Value(version),
+      isDeleted: Value(isDeleted),
+    );
+  }
+
+  factory SpaceRow.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return SpaceRow(
+      id: serializer.fromJson<String>(json['id']),
+      name: serializer.fromJson<String>(json['name']),
+      positionDx: serializer.fromJson<double>(json['positionDx']),
+      positionDy: serializer.fromJson<double>(json['positionDy']),
+      sizeWidth: serializer.fromJson<double>(json['sizeWidth']),
+      sizeHeight: serializer.fromJson<double>(json['sizeHeight']),
+      parentId: serializer.fromJson<String?>(json['parentId']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      version: serializer.fromJson<int>(json['version']),
+      isDeleted: serializer.fromJson<bool>(json['isDeleted']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'name': serializer.toJson<String>(name),
+      'positionDx': serializer.toJson<double>(positionDx),
+      'positionDy': serializer.toJson<double>(positionDy),
+      'sizeWidth': serializer.toJson<double>(sizeWidth),
+      'sizeHeight': serializer.toJson<double>(sizeHeight),
+      'parentId': serializer.toJson<String?>(parentId),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+      'version': serializer.toJson<int>(version),
+      'isDeleted': serializer.toJson<bool>(isDeleted),
+    };
+  }
+
+  SpaceRow copyWith(
+          {String? id,
+          String? name,
+          double? positionDx,
+          double? positionDy,
+          double? sizeWidth,
+          double? sizeHeight,
+          Value<String?> parentId = const Value.absent(),
+          int? updatedAt,
+          int? version,
+          bool? isDeleted}) =>
+      SpaceRow(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        positionDx: positionDx ?? this.positionDx,
+        positionDy: positionDy ?? this.positionDy,
+        sizeWidth: sizeWidth ?? this.sizeWidth,
+        sizeHeight: sizeHeight ?? this.sizeHeight,
+        parentId: parentId.present ? parentId.value : this.parentId,
+        updatedAt: updatedAt ?? this.updatedAt,
+        version: version ?? this.version,
+        isDeleted: isDeleted ?? this.isDeleted,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('SpaceRow(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('positionDx: $positionDx, ')
+          ..write('positionDy: $positionDy, ')
+          ..write('sizeWidth: $sizeWidth, ')
+          ..write('sizeHeight: $sizeHeight, ')
+          ..write('parentId: $parentId, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('isDeleted: $isDeleted')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, name, positionDx, positionDy, sizeWidth,
+      sizeHeight, parentId, updatedAt, version, isDeleted);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SpaceRow &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.positionDx == this.positionDx &&
+          other.positionDy == this.positionDy &&
+          other.sizeWidth == this.sizeWidth &&
+          other.sizeHeight == this.sizeHeight &&
+          other.parentId == this.parentId &&
+          other.updatedAt == this.updatedAt &&
+          other.version == this.version &&
+          other.isDeleted == this.isDeleted);
+}
+
+class SpacesTableCompanion extends UpdateCompanion<SpaceRow> {
+  final Value<String> id;
+  final Value<String> name;
+  final Value<double> positionDx;
+  final Value<double> positionDy;
+  final Value<double> sizeWidth;
+  final Value<double> sizeHeight;
+  final Value<String?> parentId;
+  final Value<int> updatedAt;
+  final Value<int> version;
+  final Value<bool> isDeleted;
+  final Value<int> rowid;
+  const SpacesTableCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.positionDx = const Value.absent(),
+    this.positionDy = const Value.absent(),
+    this.sizeWidth = const Value.absent(),
+    this.sizeHeight = const Value.absent(),
+    this.parentId = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.version = const Value.absent(),
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SpacesTableCompanion.insert({
+    required String id,
+    required String name,
+    required double positionDx,
+    required double positionDy,
+    required double sizeWidth,
+    required double sizeHeight,
+    this.parentId = const Value.absent(),
+    required int updatedAt,
+    required int version,
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  })  : id = Value(id),
+        name = Value(name),
+        positionDx = Value(positionDx),
+        positionDy = Value(positionDy),
+        sizeWidth = Value(sizeWidth),
+        sizeHeight = Value(sizeHeight),
+        updatedAt = Value(updatedAt),
+        version = Value(version);
+  static Insertable<SpaceRow> custom({
+    Expression<String>? id,
+    Expression<String>? name,
+    Expression<double>? positionDx,
+    Expression<double>? positionDy,
+    Expression<double>? sizeWidth,
+    Expression<double>? sizeHeight,
+    Expression<String>? parentId,
+    Expression<int>? updatedAt,
+    Expression<int>? version,
+    Expression<bool>? isDeleted,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (positionDx != null) 'position_dx': positionDx,
+      if (positionDy != null) 'position_dy': positionDy,
+      if (sizeWidth != null) 'size_width': sizeWidth,
+      if (sizeHeight != null) 'size_height': sizeHeight,
+      if (parentId != null) 'parent_id': parentId,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (version != null) 'version': version,
+      if (isDeleted != null) 'is_deleted': isDeleted,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SpacesTableCompanion copyWith(
+      {Value<String>? id,
+      Value<String>? name,
+      Value<double>? positionDx,
+      Value<double>? positionDy,
+      Value<double>? sizeWidth,
+      Value<double>? sizeHeight,
+      Value<String?>? parentId,
+      Value<int>? updatedAt,
+      Value<int>? version,
+      Value<bool>? isDeleted,
+      Value<int>? rowid}) {
+    return SpacesTableCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      positionDx: positionDx ?? this.positionDx,
+      positionDy: positionDy ?? this.positionDy,
+      sizeWidth: sizeWidth ?? this.sizeWidth,
+      sizeHeight: sizeHeight ?? this.sizeHeight,
+      parentId: parentId ?? this.parentId,
+      updatedAt: updatedAt ?? this.updatedAt,
+      version: version ?? this.version,
+      isDeleted: isDeleted ?? this.isDeleted,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (positionDx.present) {
+      map['position_dx'] = Variable<double>(positionDx.value);
+    }
+    if (positionDy.present) {
+      map['position_dy'] = Variable<double>(positionDy.value);
+    }
+    if (sizeWidth.present) {
+      map['size_width'] = Variable<double>(sizeWidth.value);
+    }
+    if (sizeHeight.present) {
+      map['size_height'] = Variable<double>(sizeHeight.value);
+    }
+    if (parentId.present) {
+      map['parent_id'] = Variable<String>(parentId.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (version.present) {
+      map['version'] = Variable<int>(version.value);
+    }
+    if (isDeleted.present) {
+      map['is_deleted'] = Variable<bool>(isDeleted.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SpacesTableCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('positionDx: $positionDx, ')
+          ..write('positionDy: $positionDy, ')
+          ..write('sizeWidth: $sizeWidth, ')
+          ..write('sizeHeight: $sizeHeight, ')
+          ..write('parentId: $parentId, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('isDeleted: $isDeleted, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $ItemsTableTable extends ItemsTable
+    with TableInfo<$ItemsTableTable, ItemRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ItemsTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+      'id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _spaceIdMeta =
+      const VerificationMeta('spaceId');
+  @override
+  late final GeneratedColumn<String> spaceId = GeneratedColumn<String>(
+      'space_id', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: 'REFERENCES spaces(id) ON DELETE CASCADE NOT NULL');
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _descriptionMeta =
+      const VerificationMeta('description');
+  @override
+  late final GeneratedColumn<String> description = GeneratedColumn<String>(
+      'description', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _locationSpecificationMeta =
+      const VerificationMeta('locationSpecification');
+  @override
+  late final GeneratedColumn<String> locationSpecification =
+      GeneratedColumn<String>('location_specification', aliasedName, true,
+          type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _tagsJsonMeta =
+      const VerificationMeta('tagsJson');
+  @override
+  late final GeneratedColumn<String> tagsJson = GeneratedColumn<String>(
+      'tags_json', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _imagePathMeta =
+      const VerificationMeta('imagePath');
+  @override
+  late final GeneratedColumn<String> imagePath = GeneratedColumn<String>(
+      'image_path', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _versionMeta =
+      const VerificationMeta('version');
+  @override
+  late final GeneratedColumn<int> version = GeneratedColumn<int>(
+      'version', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _isDeletedMeta =
+      const VerificationMeta('isDeleted');
+  @override
+  late final GeneratedColumn<bool> isDeleted = GeneratedColumn<bool>(
+      'is_deleted', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_deleted" IN (0, 1))'),
+      defaultValue: const Constant(false));
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        spaceId,
+        name,
+        description,
+        locationSpecification,
+        tagsJson,
+        imagePath,
+        updatedAt,
+        version,
+        isDeleted
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'items';
+  @override
+  VerificationContext validateIntegrity(Insertable<ItemRow> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('space_id')) {
+      context.handle(_spaceIdMeta,
+          spaceId.isAcceptableOrUnknown(data['space_id']!, _spaceIdMeta));
+    } else if (isInserting) {
+      context.missing(_spaceIdMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('description')) {
+      context.handle(
+          _descriptionMeta,
+          description.isAcceptableOrUnknown(
+              data['description']!, _descriptionMeta));
+    } else if (isInserting) {
+      context.missing(_descriptionMeta);
+    }
+    if (data.containsKey('location_specification')) {
+      context.handle(
+          _locationSpecificationMeta,
+          locationSpecification.isAcceptableOrUnknown(
+              data['location_specification']!, _locationSpecificationMeta));
+    }
+    if (data.containsKey('tags_json')) {
+      context.handle(_tagsJsonMeta,
+          tagsJson.isAcceptableOrUnknown(data['tags_json']!, _tagsJsonMeta));
+    }
+    if (data.containsKey('image_path')) {
+      context.handle(_imagePathMeta,
+          imagePath.isAcceptableOrUnknown(data['image_path']!, _imagePathMeta));
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('version')) {
+      context.handle(_versionMeta,
+          version.isAcceptableOrUnknown(data['version']!, _versionMeta));
+    } else if (isInserting) {
+      context.missing(_versionMeta);
+    }
+    if (data.containsKey('is_deleted')) {
+      context.handle(_isDeletedMeta,
+          isDeleted.isAcceptableOrUnknown(data['is_deleted']!, _isDeletedMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  ItemRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ItemRow(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}id'])!,
+      spaceId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}space_id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      description: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}description'])!,
+      locationSpecification: attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}location_specification']),
+      tagsJson: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}tags_json']),
+      imagePath: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}image_path']),
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      version: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}version'])!,
+      isDeleted: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_deleted'])!,
+    );
+  }
+
+  @override
+  $ItemsTableTable createAlias(String alias) {
+    return $ItemsTableTable(attachedDatabase, alias);
+  }
+}
+
+class ItemRow extends DataClass implements Insertable<ItemRow> {
+  final String id;
+  final String spaceId;
+  final String name;
+  final String description;
+  final String? locationSpecification;
+  final String? tagsJson;
+  final String? imagePath;
+  final int updatedAt;
+  final int version;
+  final bool isDeleted;
+  const ItemRow(
+      {required this.id,
+      required this.spaceId,
+      required this.name,
+      required this.description,
+      this.locationSpecification,
+      this.tagsJson,
+      this.imagePath,
+      required this.updatedAt,
+      required this.version,
+      required this.isDeleted});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['space_id'] = Variable<String>(spaceId);
+    map['name'] = Variable<String>(name);
+    map['description'] = Variable<String>(description);
+    if (!nullToAbsent || locationSpecification != null) {
+      map['location_specification'] = Variable<String>(locationSpecification);
+    }
+    if (!nullToAbsent || tagsJson != null) {
+      map['tags_json'] = Variable<String>(tagsJson);
+    }
+    if (!nullToAbsent || imagePath != null) {
+      map['image_path'] = Variable<String>(imagePath);
+    }
+    map['updated_at'] = Variable<int>(updatedAt);
+    map['version'] = Variable<int>(version);
+    map['is_deleted'] = Variable<bool>(isDeleted);
+    return map;
+  }
+
+  ItemsTableCompanion toCompanion(bool nullToAbsent) {
+    return ItemsTableCompanion(
+      id: Value(id),
+      spaceId: Value(spaceId),
+      name: Value(name),
+      description: Value(description),
+      locationSpecification: locationSpecification == null && nullToAbsent
+          ? const Value.absent()
+          : Value(locationSpecification),
+      tagsJson: tagsJson == null && nullToAbsent
+          ? const Value.absent()
+          : Value(tagsJson),
+      imagePath: imagePath == null && nullToAbsent
+          ? const Value.absent()
+          : Value(imagePath),
+      updatedAt: Value(updatedAt),
+      version: Value(version),
+      isDeleted: Value(isDeleted),
+    );
+  }
+
+  factory ItemRow.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ItemRow(
+      id: serializer.fromJson<String>(json['id']),
+      spaceId: serializer.fromJson<String>(json['spaceId']),
+      name: serializer.fromJson<String>(json['name']),
+      description: serializer.fromJson<String>(json['description']),
+      locationSpecification:
+          serializer.fromJson<String?>(json['locationSpecification']),
+      tagsJson: serializer.fromJson<String?>(json['tagsJson']),
+      imagePath: serializer.fromJson<String?>(json['imagePath']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      version: serializer.fromJson<int>(json['version']),
+      isDeleted: serializer.fromJson<bool>(json['isDeleted']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'spaceId': serializer.toJson<String>(spaceId),
+      'name': serializer.toJson<String>(name),
+      'description': serializer.toJson<String>(description),
+      'locationSpecification':
+          serializer.toJson<String?>(locationSpecification),
+      'tagsJson': serializer.toJson<String?>(tagsJson),
+      'imagePath': serializer.toJson<String?>(imagePath),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+      'version': serializer.toJson<int>(version),
+      'isDeleted': serializer.toJson<bool>(isDeleted),
+    };
+  }
+
+  ItemRow copyWith(
+          {String? id,
+          String? spaceId,
+          String? name,
+          String? description,
+          Value<String?> locationSpecification = const Value.absent(),
+          Value<String?> tagsJson = const Value.absent(),
+          Value<String?> imagePath = const Value.absent(),
+          int? updatedAt,
+          int? version,
+          bool? isDeleted}) =>
+      ItemRow(
+        id: id ?? this.id,
+        spaceId: spaceId ?? this.spaceId,
+        name: name ?? this.name,
+        description: description ?? this.description,
+        locationSpecification: locationSpecification.present
+            ? locationSpecification.value
+            : this.locationSpecification,
+        tagsJson: tagsJson.present ? tagsJson.value : this.tagsJson,
+        imagePath: imagePath.present ? imagePath.value : this.imagePath,
+        updatedAt: updatedAt ?? this.updatedAt,
+        version: version ?? this.version,
+        isDeleted: isDeleted ?? this.isDeleted,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('ItemRow(')
+          ..write('id: $id, ')
+          ..write('spaceId: $spaceId, ')
+          ..write('name: $name, ')
+          ..write('description: $description, ')
+          ..write('locationSpecification: $locationSpecification, ')
+          ..write('tagsJson: $tagsJson, ')
+          ..write('imagePath: $imagePath, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('isDeleted: $isDeleted')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      id,
+      spaceId,
+      name,
+      description,
+      locationSpecification,
+      tagsJson,
+      imagePath,
+      updatedAt,
+      version,
+      isDeleted);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ItemRow &&
+          other.id == this.id &&
+          other.spaceId == this.spaceId &&
+          other.name == this.name &&
+          other.description == this.description &&
+          other.locationSpecification == this.locationSpecification &&
+          other.tagsJson == this.tagsJson &&
+          other.imagePath == this.imagePath &&
+          other.updatedAt == this.updatedAt &&
+          other.version == this.version &&
+          other.isDeleted == this.isDeleted);
+}
+
+class ItemsTableCompanion extends UpdateCompanion<ItemRow> {
+  final Value<String> id;
+  final Value<String> spaceId;
+  final Value<String> name;
+  final Value<String> description;
+  final Value<String?> locationSpecification;
+  final Value<String?> tagsJson;
+  final Value<String?> imagePath;
+  final Value<int> updatedAt;
+  final Value<int> version;
+  final Value<bool> isDeleted;
+  final Value<int> rowid;
+  const ItemsTableCompanion({
+    this.id = const Value.absent(),
+    this.spaceId = const Value.absent(),
+    this.name = const Value.absent(),
+    this.description = const Value.absent(),
+    this.locationSpecification = const Value.absent(),
+    this.tagsJson = const Value.absent(),
+    this.imagePath = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.version = const Value.absent(),
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  ItemsTableCompanion.insert({
+    required String id,
+    required String spaceId,
+    required String name,
+    required String description,
+    this.locationSpecification = const Value.absent(),
+    this.tagsJson = const Value.absent(),
+    this.imagePath = const Value.absent(),
+    required int updatedAt,
+    required int version,
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  })  : id = Value(id),
+        spaceId = Value(spaceId),
+        name = Value(name),
+        description = Value(description),
+        updatedAt = Value(updatedAt),
+        version = Value(version);
+  static Insertable<ItemRow> custom({
+    Expression<String>? id,
+    Expression<String>? spaceId,
+    Expression<String>? name,
+    Expression<String>? description,
+    Expression<String>? locationSpecification,
+    Expression<String>? tagsJson,
+    Expression<String>? imagePath,
+    Expression<int>? updatedAt,
+    Expression<int>? version,
+    Expression<bool>? isDeleted,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (spaceId != null) 'space_id': spaceId,
+      if (name != null) 'name': name,
+      if (description != null) 'description': description,
+      if (locationSpecification != null)
+        'location_specification': locationSpecification,
+      if (tagsJson != null) 'tags_json': tagsJson,
+      if (imagePath != null) 'image_path': imagePath,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (version != null) 'version': version,
+      if (isDeleted != null) 'is_deleted': isDeleted,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  ItemsTableCompanion copyWith(
+      {Value<String>? id,
+      Value<String>? spaceId,
+      Value<String>? name,
+      Value<String>? description,
+      Value<String?>? locationSpecification,
+      Value<String?>? tagsJson,
+      Value<String?>? imagePath,
+      Value<int>? updatedAt,
+      Value<int>? version,
+      Value<bool>? isDeleted,
+      Value<int>? rowid}) {
+    return ItemsTableCompanion(
+      id: id ?? this.id,
+      spaceId: spaceId ?? this.spaceId,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      locationSpecification:
+          locationSpecification ?? this.locationSpecification,
+      tagsJson: tagsJson ?? this.tagsJson,
+      imagePath: imagePath ?? this.imagePath,
+      updatedAt: updatedAt ?? this.updatedAt,
+      version: version ?? this.version,
+      isDeleted: isDeleted ?? this.isDeleted,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (spaceId.present) {
+      map['space_id'] = Variable<String>(spaceId.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (description.present) {
+      map['description'] = Variable<String>(description.value);
+    }
+    if (locationSpecification.present) {
+      map['location_specification'] =
+          Variable<String>(locationSpecification.value);
+    }
+    if (tagsJson.present) {
+      map['tags_json'] = Variable<String>(tagsJson.value);
+    }
+    if (imagePath.present) {
+      map['image_path'] = Variable<String>(imagePath.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (version.present) {
+      map['version'] = Variable<int>(version.value);
+    }
+    if (isDeleted.present) {
+      map['is_deleted'] = Variable<bool>(isDeleted.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ItemsTableCompanion(')
+          ..write('id: $id, ')
+          ..write('spaceId: $spaceId, ')
+          ..write('name: $name, ')
+          ..write('description: $description, ')
+          ..write('locationSpecification: $locationSpecification, ')
+          ..write('tagsJson: $tagsJson, ')
+          ..write('imagePath: $imagePath, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('isDeleted: $isDeleted, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $UsersTableTable extends UsersTable
+    with TableInfo<$UsersTableTable, UserRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $UsersTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+      'id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _emailMeta = const VerificationMeta('email');
+  @override
+  late final GeneratedColumn<String> email = GeneratedColumn<String>(
+      'email', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _displayNameMeta =
+      const VerificationMeta('displayName');
+  @override
+  late final GeneratedColumn<String> displayName = GeneratedColumn<String>(
+      'display_name', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _avatarUrlMeta =
+      const VerificationMeta('avatarUrl');
+  @override
+  late final GeneratedColumn<String> avatarUrl = GeneratedColumn<String>(
+      'avatar_url', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _isCurrentMeta =
+      const VerificationMeta('isCurrent');
+  @override
+  late final GeneratedColumn<bool> isCurrent = GeneratedColumn<bool>(
+      'is_current', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_current" IN (0, 1))'),
+      defaultValue: const Constant(false));
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _versionMeta =
+      const VerificationMeta('version');
+  @override
+  late final GeneratedColumn<int> version = GeneratedColumn<int>(
+      'version', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _isDeletedMeta =
+      const VerificationMeta('isDeleted');
+  @override
+  late final GeneratedColumn<bool> isDeleted = GeneratedColumn<bool>(
+      'is_deleted', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_deleted" IN (0, 1))'),
+      defaultValue: const Constant(false));
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        email,
+        displayName,
+        avatarUrl,
+        isCurrent,
+        updatedAt,
+        version,
+        isDeleted
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'users';
+  @override
+  VerificationContext validateIntegrity(Insertable<UserRow> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('email')) {
+      context.handle(
+          _emailMeta, email.isAcceptableOrUnknown(data['email']!, _emailMeta));
+    } else if (isInserting) {
+      context.missing(_emailMeta);
+    }
+    if (data.containsKey('display_name')) {
+      context.handle(
+          _displayNameMeta,
+          displayName.isAcceptableOrUnknown(
+              data['display_name']!, _displayNameMeta));
+    }
+    if (data.containsKey('avatar_url')) {
+      context.handle(_avatarUrlMeta,
+          avatarUrl.isAcceptableOrUnknown(data['avatar_url']!, _avatarUrlMeta));
+    }
+    if (data.containsKey('is_current')) {
+      context.handle(_isCurrentMeta,
+          isCurrent.isAcceptableOrUnknown(data['is_current']!, _isCurrentMeta));
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('version')) {
+      context.handle(_versionMeta,
+          version.isAcceptableOrUnknown(data['version']!, _versionMeta));
+    } else if (isInserting) {
+      context.missing(_versionMeta);
+    }
+    if (data.containsKey('is_deleted')) {
+      context.handle(_isDeletedMeta,
+          isDeleted.isAcceptableOrUnknown(data['is_deleted']!, _isDeletedMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  UserRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return UserRow(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}id'])!,
+      email: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}email'])!,
+      displayName: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}display_name']),
+      avatarUrl: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}avatar_url']),
+      isCurrent: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_current'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      version: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}version'])!,
+      isDeleted: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_deleted'])!,
+    );
+  }
+
+  @override
+  $UsersTableTable createAlias(String alias) {
+    return $UsersTableTable(attachedDatabase, alias);
+  }
+}
+
+class UserRow extends DataClass implements Insertable<UserRow> {
+  final String id;
+  final String email;
+  final String? displayName;
+  final String? avatarUrl;
+  final bool isCurrent;
+  final int updatedAt;
+  final int version;
+  final bool isDeleted;
+  const UserRow(
+      {required this.id,
+      required this.email,
+      this.displayName,
+      this.avatarUrl,
+      required this.isCurrent,
+      required this.updatedAt,
+      required this.version,
+      required this.isDeleted});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['email'] = Variable<String>(email);
+    if (!nullToAbsent || displayName != null) {
+      map['display_name'] = Variable<String>(displayName);
+    }
+    if (!nullToAbsent || avatarUrl != null) {
+      map['avatar_url'] = Variable<String>(avatarUrl);
+    }
+    map['is_current'] = Variable<bool>(isCurrent);
+    map['updated_at'] = Variable<int>(updatedAt);
+    map['version'] = Variable<int>(version);
+    map['is_deleted'] = Variable<bool>(isDeleted);
+    return map;
+  }
+
+  UsersTableCompanion toCompanion(bool nullToAbsent) {
+    return UsersTableCompanion(
+      id: Value(id),
+      email: Value(email),
+      displayName: displayName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(displayName),
+      avatarUrl: avatarUrl == null && nullToAbsent
+          ? const Value.absent()
+          : Value(avatarUrl),
+      isCurrent: Value(isCurrent),
+      updatedAt: Value(updatedAt),
+      version: Value(version),
+      isDeleted: Value(isDeleted),
+    );
+  }
+
+  factory UserRow.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return UserRow(
+      id: serializer.fromJson<String>(json['id']),
+      email: serializer.fromJson<String>(json['email']),
+      displayName: serializer.fromJson<String?>(json['displayName']),
+      avatarUrl: serializer.fromJson<String?>(json['avatarUrl']),
+      isCurrent: serializer.fromJson<bool>(json['isCurrent']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      version: serializer.fromJson<int>(json['version']),
+      isDeleted: serializer.fromJson<bool>(json['isDeleted']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'email': serializer.toJson<String>(email),
+      'displayName': serializer.toJson<String?>(displayName),
+      'avatarUrl': serializer.toJson<String?>(avatarUrl),
+      'isCurrent': serializer.toJson<bool>(isCurrent),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+      'version': serializer.toJson<int>(version),
+      'isDeleted': serializer.toJson<bool>(isDeleted),
+    };
+  }
+
+  UserRow copyWith(
+          {String? id,
+          String? email,
+          Value<String?> displayName = const Value.absent(),
+          Value<String?> avatarUrl = const Value.absent(),
+          bool? isCurrent,
+          int? updatedAt,
+          int? version,
+          bool? isDeleted}) =>
+      UserRow(
+        id: id ?? this.id,
+        email: email ?? this.email,
+        displayName: displayName.present ? displayName.value : this.displayName,
+        avatarUrl: avatarUrl.present ? avatarUrl.value : this.avatarUrl,
+        isCurrent: isCurrent ?? this.isCurrent,
+        updatedAt: updatedAt ?? this.updatedAt,
+        version: version ?? this.version,
+        isDeleted: isDeleted ?? this.isDeleted,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('UserRow(')
+          ..write('id: $id, ')
+          ..write('email: $email, ')
+          ..write('displayName: $displayName, ')
+          ..write('avatarUrl: $avatarUrl, ')
+          ..write('isCurrent: $isCurrent, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('isDeleted: $isDeleted')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, email, displayName, avatarUrl, isCurrent,
+      updatedAt, version, isDeleted);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is UserRow &&
+          other.id == this.id &&
+          other.email == this.email &&
+          other.displayName == this.displayName &&
+          other.avatarUrl == this.avatarUrl &&
+          other.isCurrent == this.isCurrent &&
+          other.updatedAt == this.updatedAt &&
+          other.version == this.version &&
+          other.isDeleted == this.isDeleted);
+}
+
+class UsersTableCompanion extends UpdateCompanion<UserRow> {
+  final Value<String> id;
+  final Value<String> email;
+  final Value<String?> displayName;
+  final Value<String?> avatarUrl;
+  final Value<bool> isCurrent;
+  final Value<int> updatedAt;
+  final Value<int> version;
+  final Value<bool> isDeleted;
+  final Value<int> rowid;
+  const UsersTableCompanion({
+    this.id = const Value.absent(),
+    this.email = const Value.absent(),
+    this.displayName = const Value.absent(),
+    this.avatarUrl = const Value.absent(),
+    this.isCurrent = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.version = const Value.absent(),
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  UsersTableCompanion.insert({
+    required String id,
+    required String email,
+    this.displayName = const Value.absent(),
+    this.avatarUrl = const Value.absent(),
+    this.isCurrent = const Value.absent(),
+    required int updatedAt,
+    required int version,
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  })  : id = Value(id),
+        email = Value(email),
+        updatedAt = Value(updatedAt),
+        version = Value(version);
+  static Insertable<UserRow> custom({
+    Expression<String>? id,
+    Expression<String>? email,
+    Expression<String>? displayName,
+    Expression<String>? avatarUrl,
+    Expression<bool>? isCurrent,
+    Expression<int>? updatedAt,
+    Expression<int>? version,
+    Expression<bool>? isDeleted,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (email != null) 'email': email,
+      if (displayName != null) 'display_name': displayName,
+      if (avatarUrl != null) 'avatar_url': avatarUrl,
+      if (isCurrent != null) 'is_current': isCurrent,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (version != null) 'version': version,
+      if (isDeleted != null) 'is_deleted': isDeleted,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  UsersTableCompanion copyWith(
+      {Value<String>? id,
+      Value<String>? email,
+      Value<String?>? displayName,
+      Value<String?>? avatarUrl,
+      Value<bool>? isCurrent,
+      Value<int>? updatedAt,
+      Value<int>? version,
+      Value<bool>? isDeleted,
+      Value<int>? rowid}) {
+    return UsersTableCompanion(
+      id: id ?? this.id,
+      email: email ?? this.email,
+      displayName: displayName ?? this.displayName,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      isCurrent: isCurrent ?? this.isCurrent,
+      updatedAt: updatedAt ?? this.updatedAt,
+      version: version ?? this.version,
+      isDeleted: isDeleted ?? this.isDeleted,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (email.present) {
+      map['email'] = Variable<String>(email.value);
+    }
+    if (displayName.present) {
+      map['display_name'] = Variable<String>(displayName.value);
+    }
+    if (avatarUrl.present) {
+      map['avatar_url'] = Variable<String>(avatarUrl.value);
+    }
+    if (isCurrent.present) {
+      map['is_current'] = Variable<bool>(isCurrent.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (version.present) {
+      map['version'] = Variable<int>(version.value);
+    }
+    if (isDeleted.present) {
+      map['is_deleted'] = Variable<bool>(isDeleted.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('UsersTableCompanion(')
+          ..write('id: $id, ')
+          ..write('email: $email, ')
+          ..write('displayName: $displayName, ')
+          ..write('avatarUrl: $avatarUrl, ')
+          ..write('isCurrent: $isCurrent, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('isDeleted: $isDeleted, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $SpaceMembershipsTableTable extends SpaceMembershipsTable
+    with TableInfo<$SpaceMembershipsTableTable, MembershipRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $SpaceMembershipsTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _spaceIdMeta =
+      const VerificationMeta('spaceId');
+  @override
+  late final GeneratedColumn<String> spaceId = GeneratedColumn<String>(
+      'space_id', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: 'REFERENCES spaces(id) ON DELETE CASCADE NOT NULL');
+  static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
+  @override
+  late final GeneratedColumn<String> userId = GeneratedColumn<String>(
+      'user_id', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: 'REFERENCES users(id) ON DELETE CASCADE NOT NULL');
+  static const VerificationMeta _roleMeta = const VerificationMeta('role');
+  @override
+  late final GeneratedColumn<String> role = GeneratedColumn<String>(
+      'role', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _joinedAtMeta =
+      const VerificationMeta('joinedAt');
+  @override
+  late final GeneratedColumn<int> joinedAt = GeneratedColumn<int>(
+      'joined_at', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
+  static const VerificationMeta _attachmentVisibilityMeta =
+      const VerificationMeta('attachmentVisibility');
+  @override
+  late final GeneratedColumn<String> attachmentVisibility =
+      GeneratedColumn<String>('attachment_visibility', aliasedName, false,
+          type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _versionMeta =
+      const VerificationMeta('version');
+  @override
+  late final GeneratedColumn<int> version = GeneratedColumn<int>(
+      'version', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _isDeletedMeta =
+      const VerificationMeta('isDeleted');
+  @override
+  late final GeneratedColumn<bool> isDeleted = GeneratedColumn<bool>(
+      'is_deleted', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_deleted" IN (0, 1))'),
+      defaultValue: const Constant(false));
+  @override
+  List<GeneratedColumn> get $columns => [
+        spaceId,
+        userId,
+        role,
+        joinedAt,
+        attachmentVisibility,
+        updatedAt,
+        version,
+        isDeleted
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'space_memberships';
+  @override
+  VerificationContext validateIntegrity(Insertable<MembershipRow> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('space_id')) {
+      context.handle(_spaceIdMeta,
+          spaceId.isAcceptableOrUnknown(data['space_id']!, _spaceIdMeta));
+    } else if (isInserting) {
+      context.missing(_spaceIdMeta);
+    }
+    if (data.containsKey('user_id')) {
+      context.handle(_userIdMeta,
+          userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta));
+    } else if (isInserting) {
+      context.missing(_userIdMeta);
+    }
+    if (data.containsKey('role')) {
+      context.handle(
+          _roleMeta, role.isAcceptableOrUnknown(data['role']!, _roleMeta));
+    } else if (isInserting) {
+      context.missing(_roleMeta);
+    }
+    if (data.containsKey('joined_at')) {
+      context.handle(_joinedAtMeta,
+          joinedAt.isAcceptableOrUnknown(data['joined_at']!, _joinedAtMeta));
+    }
+    if (data.containsKey('attachment_visibility')) {
+      context.handle(
+          _attachmentVisibilityMeta,
+          attachmentVisibility.isAcceptableOrUnknown(
+              data['attachment_visibility']!, _attachmentVisibilityMeta));
+    } else if (isInserting) {
+      context.missing(_attachmentVisibilityMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('version')) {
+      context.handle(_versionMeta,
+          version.isAcceptableOrUnknown(data['version']!, _versionMeta));
+    } else if (isInserting) {
+      context.missing(_versionMeta);
+    }
+    if (data.containsKey('is_deleted')) {
+      context.handle(_isDeletedMeta,
+          isDeleted.isAcceptableOrUnknown(data['is_deleted']!, _isDeletedMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {spaceId, userId};
+  @override
+  MembershipRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return MembershipRow(
+      spaceId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}space_id'])!,
+      userId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}user_id'])!,
+      role: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}role'])!,
+      joinedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}joined_at']),
+      attachmentVisibility: attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}attachment_visibility'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      version: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}version'])!,
+      isDeleted: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_deleted'])!,
+    );
+  }
+
+  @override
+  $SpaceMembershipsTableTable createAlias(String alias) {
+    return $SpaceMembershipsTableTable(attachedDatabase, alias);
+  }
+}
+
+class MembershipRow extends DataClass implements Insertable<MembershipRow> {
+  final String spaceId;
+  final String userId;
+  final String role;
+  final int? joinedAt;
+  final String attachmentVisibility;
+  final int updatedAt;
+  final int version;
+  final bool isDeleted;
+  const MembershipRow(
+      {required this.spaceId,
+      required this.userId,
+      required this.role,
+      this.joinedAt,
+      required this.attachmentVisibility,
+      required this.updatedAt,
+      required this.version,
+      required this.isDeleted});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['space_id'] = Variable<String>(spaceId);
+    map['user_id'] = Variable<String>(userId);
+    map['role'] = Variable<String>(role);
+    if (!nullToAbsent || joinedAt != null) {
+      map['joined_at'] = Variable<int>(joinedAt);
+    }
+    map['attachment_visibility'] = Variable<String>(attachmentVisibility);
+    map['updated_at'] = Variable<int>(updatedAt);
+    map['version'] = Variable<int>(version);
+    map['is_deleted'] = Variable<bool>(isDeleted);
+    return map;
+  }
+
+  SpaceMembershipsTableCompanion toCompanion(bool nullToAbsent) {
+    return SpaceMembershipsTableCompanion(
+      spaceId: Value(spaceId),
+      userId: Value(userId),
+      role: Value(role),
+      joinedAt: joinedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(joinedAt),
+      attachmentVisibility: Value(attachmentVisibility),
+      updatedAt: Value(updatedAt),
+      version: Value(version),
+      isDeleted: Value(isDeleted),
+    );
+  }
+
+  factory MembershipRow.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return MembershipRow(
+      spaceId: serializer.fromJson<String>(json['spaceId']),
+      userId: serializer.fromJson<String>(json['userId']),
+      role: serializer.fromJson<String>(json['role']),
+      joinedAt: serializer.fromJson<int?>(json['joinedAt']),
+      attachmentVisibility:
+          serializer.fromJson<String>(json['attachmentVisibility']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      version: serializer.fromJson<int>(json['version']),
+      isDeleted: serializer.fromJson<bool>(json['isDeleted']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'spaceId': serializer.toJson<String>(spaceId),
+      'userId': serializer.toJson<String>(userId),
+      'role': serializer.toJson<String>(role),
+      'joinedAt': serializer.toJson<int?>(joinedAt),
+      'attachmentVisibility': serializer.toJson<String>(attachmentVisibility),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+      'version': serializer.toJson<int>(version),
+      'isDeleted': serializer.toJson<bool>(isDeleted),
+    };
+  }
+
+  MembershipRow copyWith(
+          {String? spaceId,
+          String? userId,
+          String? role,
+          Value<int?> joinedAt = const Value.absent(),
+          String? attachmentVisibility,
+          int? updatedAt,
+          int? version,
+          bool? isDeleted}) =>
+      MembershipRow(
+        spaceId: spaceId ?? this.spaceId,
+        userId: userId ?? this.userId,
+        role: role ?? this.role,
+        joinedAt: joinedAt.present ? joinedAt.value : this.joinedAt,
+        attachmentVisibility: attachmentVisibility ?? this.attachmentVisibility,
+        updatedAt: updatedAt ?? this.updatedAt,
+        version: version ?? this.version,
+        isDeleted: isDeleted ?? this.isDeleted,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('MembershipRow(')
+          ..write('spaceId: $spaceId, ')
+          ..write('userId: $userId, ')
+          ..write('role: $role, ')
+          ..write('joinedAt: $joinedAt, ')
+          ..write('attachmentVisibility: $attachmentVisibility, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('isDeleted: $isDeleted')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(spaceId, userId, role, joinedAt,
+      attachmentVisibility, updatedAt, version, isDeleted);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is MembershipRow &&
+          other.spaceId == this.spaceId &&
+          other.userId == this.userId &&
+          other.role == this.role &&
+          other.joinedAt == this.joinedAt &&
+          other.attachmentVisibility == this.attachmentVisibility &&
+          other.updatedAt == this.updatedAt &&
+          other.version == this.version &&
+          other.isDeleted == this.isDeleted);
+}
+
+class SpaceMembershipsTableCompanion extends UpdateCompanion<MembershipRow> {
+  final Value<String> spaceId;
+  final Value<String> userId;
+  final Value<String> role;
+  final Value<int?> joinedAt;
+  final Value<String> attachmentVisibility;
+  final Value<int> updatedAt;
+  final Value<int> version;
+  final Value<bool> isDeleted;
+  final Value<int> rowid;
+  const SpaceMembershipsTableCompanion({
+    this.spaceId = const Value.absent(),
+    this.userId = const Value.absent(),
+    this.role = const Value.absent(),
+    this.joinedAt = const Value.absent(),
+    this.attachmentVisibility = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.version = const Value.absent(),
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SpaceMembershipsTableCompanion.insert({
+    required String spaceId,
+    required String userId,
+    required String role,
+    this.joinedAt = const Value.absent(),
+    required String attachmentVisibility,
+    required int updatedAt,
+    required int version,
+    this.isDeleted = const Value.absent(),
+    this.rowid = const Value.absent(),
+  })  : spaceId = Value(spaceId),
+        userId = Value(userId),
+        role = Value(role),
+        attachmentVisibility = Value(attachmentVisibility),
+        updatedAt = Value(updatedAt),
+        version = Value(version);
+  static Insertable<MembershipRow> custom({
+    Expression<String>? spaceId,
+    Expression<String>? userId,
+    Expression<String>? role,
+    Expression<int>? joinedAt,
+    Expression<String>? attachmentVisibility,
+    Expression<int>? updatedAt,
+    Expression<int>? version,
+    Expression<bool>? isDeleted,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (spaceId != null) 'space_id': spaceId,
+      if (userId != null) 'user_id': userId,
+      if (role != null) 'role': role,
+      if (joinedAt != null) 'joined_at': joinedAt,
+      if (attachmentVisibility != null)
+        'attachment_visibility': attachmentVisibility,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (version != null) 'version': version,
+      if (isDeleted != null) 'is_deleted': isDeleted,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SpaceMembershipsTableCompanion copyWith(
+      {Value<String>? spaceId,
+      Value<String>? userId,
+      Value<String>? role,
+      Value<int?>? joinedAt,
+      Value<String>? attachmentVisibility,
+      Value<int>? updatedAt,
+      Value<int>? version,
+      Value<bool>? isDeleted,
+      Value<int>? rowid}) {
+    return SpaceMembershipsTableCompanion(
+      spaceId: spaceId ?? this.spaceId,
+      userId: userId ?? this.userId,
+      role: role ?? this.role,
+      joinedAt: joinedAt ?? this.joinedAt,
+      attachmentVisibility: attachmentVisibility ?? this.attachmentVisibility,
+      updatedAt: updatedAt ?? this.updatedAt,
+      version: version ?? this.version,
+      isDeleted: isDeleted ?? this.isDeleted,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (spaceId.present) {
+      map['space_id'] = Variable<String>(spaceId.value);
+    }
+    if (userId.present) {
+      map['user_id'] = Variable<String>(userId.value);
+    }
+    if (role.present) {
+      map['role'] = Variable<String>(role.value);
+    }
+    if (joinedAt.present) {
+      map['joined_at'] = Variable<int>(joinedAt.value);
+    }
+    if (attachmentVisibility.present) {
+      map['attachment_visibility'] =
+          Variable<String>(attachmentVisibility.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (version.present) {
+      map['version'] = Variable<int>(version.value);
+    }
+    if (isDeleted.present) {
+      map['is_deleted'] = Variable<bool>(isDeleted.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SpaceMembershipsTableCompanion(')
+          ..write('spaceId: $spaceId, ')
+          ..write('userId: $userId, ')
+          ..write('role: $role, ')
+          ..write('joinedAt: $joinedAt, ')
+          ..write('attachmentVisibility: $attachmentVisibility, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('isDeleted: $isDeleted, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $OutboxEntriesTableTable extends OutboxEntriesTable
+    with TableInfo<$OutboxEntriesTableTable, OutboxEntryRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $OutboxEntriesTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _entityTypeMeta =
+      const VerificationMeta('entityType');
+  @override
+  late final GeneratedColumn<String> entityType = GeneratedColumn<String>(
+      'entity_type', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _entityIdMeta =
+      const VerificationMeta('entityId');
+  @override
+  late final GeneratedColumn<String> entityId = GeneratedColumn<String>(
+      'entity_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _spaceIdMeta =
+      const VerificationMeta('spaceId');
+  @override
+  late final GeneratedColumn<String> spaceId = GeneratedColumn<String>(
+      'space_id', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _operationMeta =
+      const VerificationMeta('operation');
+  @override
+  late final GeneratedColumn<String> operation = GeneratedColumn<String>(
+      'operation', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _payloadMeta =
+      const VerificationMeta('payload');
+  @override
+  late final GeneratedColumn<String> payload = GeneratedColumn<String>(
+      'payload', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _versionMeta =
+      const VerificationMeta('version');
+  @override
+  late final GeneratedColumn<int> version = GeneratedColumn<int>(
+      'version', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<int> createdAt = GeneratedColumn<int>(
+      'created_at', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        entityType,
+        entityId,
+        spaceId,
+        operation,
+        payload,
+        updatedAt,
+        version,
+        createdAt
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'outbox';
+  @override
+  VerificationContext validateIntegrity(Insertable<OutboxEntryRow> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('entity_type')) {
+      context.handle(
+          _entityTypeMeta,
+          entityType.isAcceptableOrUnknown(
+              data['entity_type']!, _entityTypeMeta));
+    } else if (isInserting) {
+      context.missing(_entityTypeMeta);
+    }
+    if (data.containsKey('entity_id')) {
+      context.handle(_entityIdMeta,
+          entityId.isAcceptableOrUnknown(data['entity_id']!, _entityIdMeta));
+    } else if (isInserting) {
+      context.missing(_entityIdMeta);
+    }
+    if (data.containsKey('space_id')) {
+      context.handle(_spaceIdMeta,
+          spaceId.isAcceptableOrUnknown(data['space_id']!, _spaceIdMeta));
+    }
+    if (data.containsKey('operation')) {
+      context.handle(_operationMeta,
+          operation.isAcceptableOrUnknown(data['operation']!, _operationMeta));
+    } else if (isInserting) {
+      context.missing(_operationMeta);
+    }
+    if (data.containsKey('payload')) {
+      context.handle(_payloadMeta,
+          payload.isAcceptableOrUnknown(data['payload']!, _payloadMeta));
+    } else if (isInserting) {
+      context.missing(_payloadMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('version')) {
+      context.handle(_versionMeta,
+          version.isAcceptableOrUnknown(data['version']!, _versionMeta));
+    } else if (isInserting) {
+      context.missing(_versionMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  OutboxEntryRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return OutboxEntryRow(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      entityType: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}entity_type'])!,
+      entityId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}entity_id'])!,
+      spaceId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}space_id']),
+      operation: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}operation'])!,
+      payload: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}payload'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}updated_at'])!,
+      version: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}version'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}created_at'])!,
+    );
+  }
+
+  @override
+  $OutboxEntriesTableTable createAlias(String alias) {
+    return $OutboxEntriesTableTable(attachedDatabase, alias);
+  }
+}
+
+class OutboxEntryRow extends DataClass implements Insertable<OutboxEntryRow> {
+  final int id;
+  final String entityType;
+  final String entityId;
+  final String? spaceId;
+  final String operation;
+  final String payload;
+  final int updatedAt;
+  final int version;
+  final int createdAt;
+  const OutboxEntryRow(
+      {required this.id,
+      required this.entityType,
+      required this.entityId,
+      this.spaceId,
+      required this.operation,
+      required this.payload,
+      required this.updatedAt,
+      required this.version,
+      required this.createdAt});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['entity_type'] = Variable<String>(entityType);
+    map['entity_id'] = Variable<String>(entityId);
+    if (!nullToAbsent || spaceId != null) {
+      map['space_id'] = Variable<String>(spaceId);
+    }
+    map['operation'] = Variable<String>(operation);
+    map['payload'] = Variable<String>(payload);
+    map['updated_at'] = Variable<int>(updatedAt);
+    map['version'] = Variable<int>(version);
+    map['created_at'] = Variable<int>(createdAt);
+    return map;
+  }
+
+  OutboxEntriesTableCompanion toCompanion(bool nullToAbsent) {
+    return OutboxEntriesTableCompanion(
+      id: Value(id),
+      entityType: Value(entityType),
+      entityId: Value(entityId),
+      spaceId: spaceId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(spaceId),
+      operation: Value(operation),
+      payload: Value(payload),
+      updatedAt: Value(updatedAt),
+      version: Value(version),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory OutboxEntryRow.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return OutboxEntryRow(
+      id: serializer.fromJson<int>(json['id']),
+      entityType: serializer.fromJson<String>(json['entityType']),
+      entityId: serializer.fromJson<String>(json['entityId']),
+      spaceId: serializer.fromJson<String?>(json['spaceId']),
+      operation: serializer.fromJson<String>(json['operation']),
+      payload: serializer.fromJson<String>(json['payload']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      version: serializer.fromJson<int>(json['version']),
+      createdAt: serializer.fromJson<int>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'entityType': serializer.toJson<String>(entityType),
+      'entityId': serializer.toJson<String>(entityId),
+      'spaceId': serializer.toJson<String?>(spaceId),
+      'operation': serializer.toJson<String>(operation),
+      'payload': serializer.toJson<String>(payload),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+      'version': serializer.toJson<int>(version),
+      'createdAt': serializer.toJson<int>(createdAt),
+    };
+  }
+
+  OutboxEntryRow copyWith(
+          {int? id,
+          String? entityType,
+          String? entityId,
+          Value<String?> spaceId = const Value.absent(),
+          String? operation,
+          String? payload,
+          int? updatedAt,
+          int? version,
+          int? createdAt}) =>
+      OutboxEntryRow(
+        id: id ?? this.id,
+        entityType: entityType ?? this.entityType,
+        entityId: entityId ?? this.entityId,
+        spaceId: spaceId.present ? spaceId.value : this.spaceId,
+        operation: operation ?? this.operation,
+        payload: payload ?? this.payload,
+        updatedAt: updatedAt ?? this.updatedAt,
+        version: version ?? this.version,
+        createdAt: createdAt ?? this.createdAt,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('OutboxEntryRow(')
+          ..write('id: $id, ')
+          ..write('entityType: $entityType, ')
+          ..write('entityId: $entityId, ')
+          ..write('spaceId: $spaceId, ')
+          ..write('operation: $operation, ')
+          ..write('payload: $payload, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, entityType, entityId, spaceId, operation,
+      payload, updatedAt, version, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is OutboxEntryRow &&
+          other.id == this.id &&
+          other.entityType == this.entityType &&
+          other.entityId == this.entityId &&
+          other.spaceId == this.spaceId &&
+          other.operation == this.operation &&
+          other.payload == this.payload &&
+          other.updatedAt == this.updatedAt &&
+          other.version == this.version &&
+          other.createdAt == this.createdAt);
+}
+
+class OutboxEntriesTableCompanion extends UpdateCompanion<OutboxEntryRow> {
+  final Value<int> id;
+  final Value<String> entityType;
+  final Value<String> entityId;
+  final Value<String?> spaceId;
+  final Value<String> operation;
+  final Value<String> payload;
+  final Value<int> updatedAt;
+  final Value<int> version;
+  final Value<int> createdAt;
+  const OutboxEntriesTableCompanion({
+    this.id = const Value.absent(),
+    this.entityType = const Value.absent(),
+    this.entityId = const Value.absent(),
+    this.spaceId = const Value.absent(),
+    this.operation = const Value.absent(),
+    this.payload = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.version = const Value.absent(),
+    this.createdAt = const Value.absent(),
+  });
+  OutboxEntriesTableCompanion.insert({
+    this.id = const Value.absent(),
+    required String entityType,
+    required String entityId,
+    this.spaceId = const Value.absent(),
+    required String operation,
+    required String payload,
+    required int updatedAt,
+    required int version,
+    required int createdAt,
+  })  : entityType = Value(entityType),
+        entityId = Value(entityId),
+        operation = Value(operation),
+        payload = Value(payload),
+        updatedAt = Value(updatedAt),
+        version = Value(version),
+        createdAt = Value(createdAt);
+  static Insertable<OutboxEntryRow> custom({
+    Expression<int>? id,
+    Expression<String>? entityType,
+    Expression<String>? entityId,
+    Expression<String>? spaceId,
+    Expression<String>? operation,
+    Expression<String>? payload,
+    Expression<int>? updatedAt,
+    Expression<int>? version,
+    Expression<int>? createdAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (entityType != null) 'entity_type': entityType,
+      if (entityId != null) 'entity_id': entityId,
+      if (spaceId != null) 'space_id': spaceId,
+      if (operation != null) 'operation': operation,
+      if (payload != null) 'payload': payload,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (version != null) 'version': version,
+      if (createdAt != null) 'created_at': createdAt,
+    });
+  }
+
+  OutboxEntriesTableCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? entityType,
+      Value<String>? entityId,
+      Value<String?>? spaceId,
+      Value<String>? operation,
+      Value<String>? payload,
+      Value<int>? updatedAt,
+      Value<int>? version,
+      Value<int>? createdAt}) {
+    return OutboxEntriesTableCompanion(
+      id: id ?? this.id,
+      entityType: entityType ?? this.entityType,
+      entityId: entityId ?? this.entityId,
+      spaceId: spaceId ?? this.spaceId,
+      operation: operation ?? this.operation,
+      payload: payload ?? this.payload,
+      updatedAt: updatedAt ?? this.updatedAt,
+      version: version ?? this.version,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (entityType.present) {
+      map['entity_type'] = Variable<String>(entityType.value);
+    }
+    if (entityId.present) {
+      map['entity_id'] = Variable<String>(entityId.value);
+    }
+    if (spaceId.present) {
+      map['space_id'] = Variable<String>(spaceId.value);
+    }
+    if (operation.present) {
+      map['operation'] = Variable<String>(operation.value);
+    }
+    if (payload.present) {
+      map['payload'] = Variable<String>(payload.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (version.present) {
+      map['version'] = Variable<int>(version.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<int>(createdAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('OutboxEntriesTableCompanion(')
+          ..write('id: $id, ')
+          ..write('entityType: $entityType, ')
+          ..write('entityId: $entityId, ')
+          ..write('spaceId: $spaceId, ')
+          ..write('operation: $operation, ')
+          ..write('payload: $payload, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('version: $version, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$LocalDatabase extends GeneratedDatabase {
+  _$LocalDatabase(QueryExecutor e) : super(e);
+  _$LocalDatabaseManager get managers => _$LocalDatabaseManager(this);
+  late final $SpacesTableTable spacesTable = $SpacesTableTable(this);
+  late final $ItemsTableTable itemsTable = $ItemsTableTable(this);
+  late final $UsersTableTable usersTable = $UsersTableTable(this);
+  late final $SpaceMembershipsTableTable spaceMembershipsTable =
+      $SpaceMembershipsTableTable(this);
+  late final $OutboxEntriesTableTable outboxEntriesTable =
+      $OutboxEntriesTableTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+        spacesTable,
+        itemsTable,
+        usersTable,
+        spaceMembershipsTable,
+        outboxEntriesTable
+      ];
+  @override
+  StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules(
+        [
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('spaces',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('items', kind: UpdateKind.delete),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('spaces',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('space_memberships', kind: UpdateKind.delete),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('users',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('space_memberships', kind: UpdateKind.delete),
+            ],
+          ),
+        ],
+      );
+}
+
+typedef $$SpacesTableTableInsertCompanionBuilder = SpacesTableCompanion
+    Function({
+  required String id,
+  required String name,
+  required double positionDx,
+  required double positionDy,
+  required double sizeWidth,
+  required double sizeHeight,
+  Value<String?> parentId,
+  required int updatedAt,
+  required int version,
+  Value<bool> isDeleted,
+  Value<int> rowid,
+});
+typedef $$SpacesTableTableUpdateCompanionBuilder = SpacesTableCompanion
+    Function({
+  Value<String> id,
+  Value<String> name,
+  Value<double> positionDx,
+  Value<double> positionDy,
+  Value<double> sizeWidth,
+  Value<double> sizeHeight,
+  Value<String?> parentId,
+  Value<int> updatedAt,
+  Value<int> version,
+  Value<bool> isDeleted,
+  Value<int> rowid,
+});
+
+class $$SpacesTableTableTableManager extends RootTableManager<
+    _$LocalDatabase,
+    $SpacesTableTable,
+    SpaceRow,
+    $$SpacesTableTableFilterComposer,
+    $$SpacesTableTableOrderingComposer,
+    $$SpacesTableTableProcessedTableManager,
+    $$SpacesTableTableInsertCompanionBuilder,
+    $$SpacesTableTableUpdateCompanionBuilder> {
+  $$SpacesTableTableTableManager(_$LocalDatabase db, $SpacesTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$SpacesTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$SpacesTableTableOrderingComposer(ComposerState(db, table)),
+          getChildManagerBuilder: (p) =>
+              $$SpacesTableTableProcessedTableManager(p),
+          getUpdateCompanionBuilder: ({
+            Value<String> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<double> positionDx = const Value.absent(),
+            Value<double> positionDy = const Value.absent(),
+            Value<double> sizeWidth = const Value.absent(),
+            Value<double> sizeHeight = const Value.absent(),
+            Value<String?> parentId = const Value.absent(),
+            Value<int> updatedAt = const Value.absent(),
+            Value<int> version = const Value.absent(),
+            Value<bool> isDeleted = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SpacesTableCompanion(
+            id: id,
+            name: name,
+            positionDx: positionDx,
+            positionDy: positionDy,
+            sizeWidth: sizeWidth,
+            sizeHeight: sizeHeight,
+            parentId: parentId,
+            updatedAt: updatedAt,
+            version: version,
+            isDeleted: isDeleted,
+            rowid: rowid,
+          ),
+          getInsertCompanionBuilder: ({
+            required String id,
+            required String name,
+            required double positionDx,
+            required double positionDy,
+            required double sizeWidth,
+            required double sizeHeight,
+            Value<String?> parentId = const Value.absent(),
+            required int updatedAt,
+            required int version,
+            Value<bool> isDeleted = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SpacesTableCompanion.insert(
+            id: id,
+            name: name,
+            positionDx: positionDx,
+            positionDy: positionDy,
+            sizeWidth: sizeWidth,
+            sizeHeight: sizeHeight,
+            parentId: parentId,
+            updatedAt: updatedAt,
+            version: version,
+            isDeleted: isDeleted,
+            rowid: rowid,
+          ),
+        ));
+}
+
+class $$SpacesTableTableProcessedTableManager extends ProcessedTableManager<
+    _$LocalDatabase,
+    $SpacesTableTable,
+    SpaceRow,
+    $$SpacesTableTableFilterComposer,
+    $$SpacesTableTableOrderingComposer,
+    $$SpacesTableTableProcessedTableManager,
+    $$SpacesTableTableInsertCompanionBuilder,
+    $$SpacesTableTableUpdateCompanionBuilder> {
+  $$SpacesTableTableProcessedTableManager(super.$state);
+}
+
+class $$SpacesTableTableFilterComposer
+    extends FilterComposer<_$LocalDatabase, $SpacesTableTable> {
+  $$SpacesTableTableFilterComposer(super.$state);
+  ColumnFilters<String> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<double> get positionDx => $state.composableBuilder(
+      column: $state.table.positionDx,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<double> get positionDy => $state.composableBuilder(
+      column: $state.table.positionDy,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<double> get sizeWidth => $state.composableBuilder(
+      column: $state.table.sizeWidth,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<double> get sizeHeight => $state.composableBuilder(
+      column: $state.table.sizeHeight,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get parentId => $state.composableBuilder(
+      column: $state.table.parentId,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get isDeleted => $state.composableBuilder(
+      column: $state.table.isDeleted,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ComposableFilter itemsTableRefs(
+      ComposableFilter Function($$ItemsTableTableFilterComposer f) f) {
+    final $$ItemsTableTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $state.db.itemsTable,
+        getReferencedColumn: (t) => t.spaceId,
+        builder: (joinBuilder, parentComposers) =>
+            $$ItemsTableTableFilterComposer(ComposerState($state.db,
+                $state.db.itemsTable, joinBuilder, parentComposers)));
+    return f(composer);
+  }
+
+  ComposableFilter spaceMembershipsTableRefs(
+      ComposableFilter Function($$SpaceMembershipsTableTableFilterComposer f)
+          f) {
+    final $$SpaceMembershipsTableTableFilterComposer composer =
+        $state.composerBuilder(
+            composer: this,
+            getCurrentColumn: (t) => t.id,
+            referencedTable: $state.db.spaceMembershipsTable,
+            getReferencedColumn: (t) => t.spaceId,
+            builder: (joinBuilder, parentComposers) =>
+                $$SpaceMembershipsTableTableFilterComposer(ComposerState(
+                    $state.db,
+                    $state.db.spaceMembershipsTable,
+                    joinBuilder,
+                    parentComposers)));
+    return f(composer);
+  }
+}
+
+class $$SpacesTableTableOrderingComposer
+    extends OrderingComposer<_$LocalDatabase, $SpacesTableTable> {
+  $$SpacesTableTableOrderingComposer(super.$state);
+  ColumnOrderings<String> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<double> get positionDx => $state.composableBuilder(
+      column: $state.table.positionDx,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<double> get positionDy => $state.composableBuilder(
+      column: $state.table.positionDy,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<double> get sizeWidth => $state.composableBuilder(
+      column: $state.table.sizeWidth,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<double> get sizeHeight => $state.composableBuilder(
+      column: $state.table.sizeHeight,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get parentId => $state.composableBuilder(
+      column: $state.table.parentId,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get isDeleted => $state.composableBuilder(
+      column: $state.table.isDeleted,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+typedef $$ItemsTableTableInsertCompanionBuilder = ItemsTableCompanion Function({
+  required String id,
+  required String spaceId,
+  required String name,
+  required String description,
+  Value<String?> locationSpecification,
+  Value<String?> tagsJson,
+  Value<String?> imagePath,
+  required int updatedAt,
+  required int version,
+  Value<bool> isDeleted,
+  Value<int> rowid,
+});
+typedef $$ItemsTableTableUpdateCompanionBuilder = ItemsTableCompanion Function({
+  Value<String> id,
+  Value<String> spaceId,
+  Value<String> name,
+  Value<String> description,
+  Value<String?> locationSpecification,
+  Value<String?> tagsJson,
+  Value<String?> imagePath,
+  Value<int> updatedAt,
+  Value<int> version,
+  Value<bool> isDeleted,
+  Value<int> rowid,
+});
+
+class $$ItemsTableTableTableManager extends RootTableManager<
+    _$LocalDatabase,
+    $ItemsTableTable,
+    ItemRow,
+    $$ItemsTableTableFilterComposer,
+    $$ItemsTableTableOrderingComposer,
+    $$ItemsTableTableProcessedTableManager,
+    $$ItemsTableTableInsertCompanionBuilder,
+    $$ItemsTableTableUpdateCompanionBuilder> {
+  $$ItemsTableTableTableManager(_$LocalDatabase db, $ItemsTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$ItemsTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$ItemsTableTableOrderingComposer(ComposerState(db, table)),
+          getChildManagerBuilder: (p) =>
+              $$ItemsTableTableProcessedTableManager(p),
+          getUpdateCompanionBuilder: ({
+            Value<String> id = const Value.absent(),
+            Value<String> spaceId = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<String> description = const Value.absent(),
+            Value<String?> locationSpecification = const Value.absent(),
+            Value<String?> tagsJson = const Value.absent(),
+            Value<String?> imagePath = const Value.absent(),
+            Value<int> updatedAt = const Value.absent(),
+            Value<int> version = const Value.absent(),
+            Value<bool> isDeleted = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ItemsTableCompanion(
+            id: id,
+            spaceId: spaceId,
+            name: name,
+            description: description,
+            locationSpecification: locationSpecification,
+            tagsJson: tagsJson,
+            imagePath: imagePath,
+            updatedAt: updatedAt,
+            version: version,
+            isDeleted: isDeleted,
+            rowid: rowid,
+          ),
+          getInsertCompanionBuilder: ({
+            required String id,
+            required String spaceId,
+            required String name,
+            required String description,
+            Value<String?> locationSpecification = const Value.absent(),
+            Value<String?> tagsJson = const Value.absent(),
+            Value<String?> imagePath = const Value.absent(),
+            required int updatedAt,
+            required int version,
+            Value<bool> isDeleted = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ItemsTableCompanion.insert(
+            id: id,
+            spaceId: spaceId,
+            name: name,
+            description: description,
+            locationSpecification: locationSpecification,
+            tagsJson: tagsJson,
+            imagePath: imagePath,
+            updatedAt: updatedAt,
+            version: version,
+            isDeleted: isDeleted,
+            rowid: rowid,
+          ),
+        ));
+}
+
+class $$ItemsTableTableProcessedTableManager extends ProcessedTableManager<
+    _$LocalDatabase,
+    $ItemsTableTable,
+    ItemRow,
+    $$ItemsTableTableFilterComposer,
+    $$ItemsTableTableOrderingComposer,
+    $$ItemsTableTableProcessedTableManager,
+    $$ItemsTableTableInsertCompanionBuilder,
+    $$ItemsTableTableUpdateCompanionBuilder> {
+  $$ItemsTableTableProcessedTableManager(super.$state);
+}
+
+class $$ItemsTableTableFilterComposer
+    extends FilterComposer<_$LocalDatabase, $ItemsTableTable> {
+  $$ItemsTableTableFilterComposer(super.$state);
+  ColumnFilters<String> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get locationSpecification => $state.composableBuilder(
+      column: $state.table.locationSpecification,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get tagsJson => $state.composableBuilder(
+      column: $state.table.tagsJson,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get imagePath => $state.composableBuilder(
+      column: $state.table.imagePath,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get isDeleted => $state.composableBuilder(
+      column: $state.table.isDeleted,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  $$SpacesTableTableFilterComposer get spaceId {
+    final $$SpacesTableTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.spaceId,
+        referencedTable: $state.db.spacesTable,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder, parentComposers) =>
+            $$SpacesTableTableFilterComposer(ComposerState($state.db,
+                $state.db.spacesTable, joinBuilder, parentComposers)));
+    return composer;
+  }
+}
+
+class $$ItemsTableTableOrderingComposer
+    extends OrderingComposer<_$LocalDatabase, $ItemsTableTable> {
+  $$ItemsTableTableOrderingComposer(super.$state);
+  ColumnOrderings<String> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get locationSpecification => $state.composableBuilder(
+      column: $state.table.locationSpecification,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get tagsJson => $state.composableBuilder(
+      column: $state.table.tagsJson,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get imagePath => $state.composableBuilder(
+      column: $state.table.imagePath,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get isDeleted => $state.composableBuilder(
+      column: $state.table.isDeleted,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  $$SpacesTableTableOrderingComposer get spaceId {
+    final $$SpacesTableTableOrderingComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.spaceId,
+        referencedTable: $state.db.spacesTable,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder, parentComposers) =>
+            $$SpacesTableTableOrderingComposer(ComposerState($state.db,
+                $state.db.spacesTable, joinBuilder, parentComposers)));
+    return composer;
+  }
+}
+
+typedef $$UsersTableTableInsertCompanionBuilder = UsersTableCompanion Function({
+  required String id,
+  required String email,
+  Value<String?> displayName,
+  Value<String?> avatarUrl,
+  Value<bool> isCurrent,
+  required int updatedAt,
+  required int version,
+  Value<bool> isDeleted,
+  Value<int> rowid,
+});
+typedef $$UsersTableTableUpdateCompanionBuilder = UsersTableCompanion Function({
+  Value<String> id,
+  Value<String> email,
+  Value<String?> displayName,
+  Value<String?> avatarUrl,
+  Value<bool> isCurrent,
+  Value<int> updatedAt,
+  Value<int> version,
+  Value<bool> isDeleted,
+  Value<int> rowid,
+});
+
+class $$UsersTableTableTableManager extends RootTableManager<
+    _$LocalDatabase,
+    $UsersTableTable,
+    UserRow,
+    $$UsersTableTableFilterComposer,
+    $$UsersTableTableOrderingComposer,
+    $$UsersTableTableProcessedTableManager,
+    $$UsersTableTableInsertCompanionBuilder,
+    $$UsersTableTableUpdateCompanionBuilder> {
+  $$UsersTableTableTableManager(_$LocalDatabase db, $UsersTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$UsersTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$UsersTableTableOrderingComposer(ComposerState(db, table)),
+          getChildManagerBuilder: (p) =>
+              $$UsersTableTableProcessedTableManager(p),
+          getUpdateCompanionBuilder: ({
+            Value<String> id = const Value.absent(),
+            Value<String> email = const Value.absent(),
+            Value<String?> displayName = const Value.absent(),
+            Value<String?> avatarUrl = const Value.absent(),
+            Value<bool> isCurrent = const Value.absent(),
+            Value<int> updatedAt = const Value.absent(),
+            Value<int> version = const Value.absent(),
+            Value<bool> isDeleted = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              UsersTableCompanion(
+            id: id,
+            email: email,
+            displayName: displayName,
+            avatarUrl: avatarUrl,
+            isCurrent: isCurrent,
+            updatedAt: updatedAt,
+            version: version,
+            isDeleted: isDeleted,
+            rowid: rowid,
+          ),
+          getInsertCompanionBuilder: ({
+            required String id,
+            required String email,
+            Value<String?> displayName = const Value.absent(),
+            Value<String?> avatarUrl = const Value.absent(),
+            Value<bool> isCurrent = const Value.absent(),
+            required int updatedAt,
+            required int version,
+            Value<bool> isDeleted = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              UsersTableCompanion.insert(
+            id: id,
+            email: email,
+            displayName: displayName,
+            avatarUrl: avatarUrl,
+            isCurrent: isCurrent,
+            updatedAt: updatedAt,
+            version: version,
+            isDeleted: isDeleted,
+            rowid: rowid,
+          ),
+        ));
+}
+
+class $$UsersTableTableProcessedTableManager extends ProcessedTableManager<
+    _$LocalDatabase,
+    $UsersTableTable,
+    UserRow,
+    $$UsersTableTableFilterComposer,
+    $$UsersTableTableOrderingComposer,
+    $$UsersTableTableProcessedTableManager,
+    $$UsersTableTableInsertCompanionBuilder,
+    $$UsersTableTableUpdateCompanionBuilder> {
+  $$UsersTableTableProcessedTableManager(super.$state);
+}
+
+class $$UsersTableTableFilterComposer
+    extends FilterComposer<_$LocalDatabase, $UsersTableTable> {
+  $$UsersTableTableFilterComposer(super.$state);
+  ColumnFilters<String> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get email => $state.composableBuilder(
+      column: $state.table.email,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get displayName => $state.composableBuilder(
+      column: $state.table.displayName,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get avatarUrl => $state.composableBuilder(
+      column: $state.table.avatarUrl,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get isCurrent => $state.composableBuilder(
+      column: $state.table.isCurrent,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get isDeleted => $state.composableBuilder(
+      column: $state.table.isDeleted,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ComposableFilter spaceMembershipsTableRefs(
+      ComposableFilter Function($$SpaceMembershipsTableTableFilterComposer f)
+          f) {
+    final $$SpaceMembershipsTableTableFilterComposer composer =
+        $state.composerBuilder(
+            composer: this,
+            getCurrentColumn: (t) => t.id,
+            referencedTable: $state.db.spaceMembershipsTable,
+            getReferencedColumn: (t) => t.userId,
+            builder: (joinBuilder, parentComposers) =>
+                $$SpaceMembershipsTableTableFilterComposer(ComposerState(
+                    $state.db,
+                    $state.db.spaceMembershipsTable,
+                    joinBuilder,
+                    parentComposers)));
+    return f(composer);
+  }
+}
+
+class $$UsersTableTableOrderingComposer
+    extends OrderingComposer<_$LocalDatabase, $UsersTableTable> {
+  $$UsersTableTableOrderingComposer(super.$state);
+  ColumnOrderings<String> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get email => $state.composableBuilder(
+      column: $state.table.email,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get displayName => $state.composableBuilder(
+      column: $state.table.displayName,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get avatarUrl => $state.composableBuilder(
+      column: $state.table.avatarUrl,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get isCurrent => $state.composableBuilder(
+      column: $state.table.isCurrent,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get isDeleted => $state.composableBuilder(
+      column: $state.table.isDeleted,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+typedef $$SpaceMembershipsTableTableInsertCompanionBuilder
+    = SpaceMembershipsTableCompanion Function({
+  required String spaceId,
+  required String userId,
+  required String role,
+  Value<int?> joinedAt,
+  required String attachmentVisibility,
+  required int updatedAt,
+  required int version,
+  Value<bool> isDeleted,
+  Value<int> rowid,
+});
+typedef $$SpaceMembershipsTableTableUpdateCompanionBuilder
+    = SpaceMembershipsTableCompanion Function({
+  Value<String> spaceId,
+  Value<String> userId,
+  Value<String> role,
+  Value<int?> joinedAt,
+  Value<String> attachmentVisibility,
+  Value<int> updatedAt,
+  Value<int> version,
+  Value<bool> isDeleted,
+  Value<int> rowid,
+});
+
+class $$SpaceMembershipsTableTableTableManager extends RootTableManager<
+    _$LocalDatabase,
+    $SpaceMembershipsTableTable,
+    MembershipRow,
+    $$SpaceMembershipsTableTableFilterComposer,
+    $$SpaceMembershipsTableTableOrderingComposer,
+    $$SpaceMembershipsTableTableProcessedTableManager,
+    $$SpaceMembershipsTableTableInsertCompanionBuilder,
+    $$SpaceMembershipsTableTableUpdateCompanionBuilder> {
+  $$SpaceMembershipsTableTableTableManager(
+      _$LocalDatabase db, $SpaceMembershipsTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $$SpaceMembershipsTableTableFilterComposer(
+              ComposerState(db, table)),
+          orderingComposer: $$SpaceMembershipsTableTableOrderingComposer(
+              ComposerState(db, table)),
+          getChildManagerBuilder: (p) =>
+              $$SpaceMembershipsTableTableProcessedTableManager(p),
+          getUpdateCompanionBuilder: ({
+            Value<String> spaceId = const Value.absent(),
+            Value<String> userId = const Value.absent(),
+            Value<String> role = const Value.absent(),
+            Value<int?> joinedAt = const Value.absent(),
+            Value<String> attachmentVisibility = const Value.absent(),
+            Value<int> updatedAt = const Value.absent(),
+            Value<int> version = const Value.absent(),
+            Value<bool> isDeleted = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SpaceMembershipsTableCompanion(
+            spaceId: spaceId,
+            userId: userId,
+            role: role,
+            joinedAt: joinedAt,
+            attachmentVisibility: attachmentVisibility,
+            updatedAt: updatedAt,
+            version: version,
+            isDeleted: isDeleted,
+            rowid: rowid,
+          ),
+          getInsertCompanionBuilder: ({
+            required String spaceId,
+            required String userId,
+            required String role,
+            Value<int?> joinedAt = const Value.absent(),
+            required String attachmentVisibility,
+            required int updatedAt,
+            required int version,
+            Value<bool> isDeleted = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SpaceMembershipsTableCompanion.insert(
+            spaceId: spaceId,
+            userId: userId,
+            role: role,
+            joinedAt: joinedAt,
+            attachmentVisibility: attachmentVisibility,
+            updatedAt: updatedAt,
+            version: version,
+            isDeleted: isDeleted,
+            rowid: rowid,
+          ),
+        ));
+}
+
+class $$SpaceMembershipsTableTableProcessedTableManager
+    extends ProcessedTableManager<
+        _$LocalDatabase,
+        $SpaceMembershipsTableTable,
+        MembershipRow,
+        $$SpaceMembershipsTableTableFilterComposer,
+        $$SpaceMembershipsTableTableOrderingComposer,
+        $$SpaceMembershipsTableTableProcessedTableManager,
+        $$SpaceMembershipsTableTableInsertCompanionBuilder,
+        $$SpaceMembershipsTableTableUpdateCompanionBuilder> {
+  $$SpaceMembershipsTableTableProcessedTableManager(super.$state);
+}
+
+class $$SpaceMembershipsTableTableFilterComposer
+    extends FilterComposer<_$LocalDatabase, $SpaceMembershipsTableTable> {
+  $$SpaceMembershipsTableTableFilterComposer(super.$state);
+  ColumnFilters<String> get role => $state.composableBuilder(
+      column: $state.table.role,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get joinedAt => $state.composableBuilder(
+      column: $state.table.joinedAt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get attachmentVisibility => $state.composableBuilder(
+      column: $state.table.attachmentVisibility,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get isDeleted => $state.composableBuilder(
+      column: $state.table.isDeleted,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  $$SpacesTableTableFilterComposer get spaceId {
+    final $$SpacesTableTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.spaceId,
+        referencedTable: $state.db.spacesTable,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder, parentComposers) =>
+            $$SpacesTableTableFilterComposer(ComposerState($state.db,
+                $state.db.spacesTable, joinBuilder, parentComposers)));
+    return composer;
+  }
+
+  $$UsersTableTableFilterComposer get userId {
+    final $$UsersTableTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.userId,
+        referencedTable: $state.db.usersTable,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder, parentComposers) =>
+            $$UsersTableTableFilterComposer(ComposerState($state.db,
+                $state.db.usersTable, joinBuilder, parentComposers)));
+    return composer;
+  }
+}
+
+class $$SpaceMembershipsTableTableOrderingComposer
+    extends OrderingComposer<_$LocalDatabase, $SpaceMembershipsTableTable> {
+  $$SpaceMembershipsTableTableOrderingComposer(super.$state);
+  ColumnOrderings<String> get role => $state.composableBuilder(
+      column: $state.table.role,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get joinedAt => $state.composableBuilder(
+      column: $state.table.joinedAt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get attachmentVisibility => $state.composableBuilder(
+      column: $state.table.attachmentVisibility,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get isDeleted => $state.composableBuilder(
+      column: $state.table.isDeleted,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  $$SpacesTableTableOrderingComposer get spaceId {
+    final $$SpacesTableTableOrderingComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.spaceId,
+        referencedTable: $state.db.spacesTable,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder, parentComposers) =>
+            $$SpacesTableTableOrderingComposer(ComposerState($state.db,
+                $state.db.spacesTable, joinBuilder, parentComposers)));
+    return composer;
+  }
+
+  $$UsersTableTableOrderingComposer get userId {
+    final $$UsersTableTableOrderingComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.userId,
+        referencedTable: $state.db.usersTable,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder, parentComposers) =>
+            $$UsersTableTableOrderingComposer(ComposerState($state.db,
+                $state.db.usersTable, joinBuilder, parentComposers)));
+    return composer;
+  }
+}
+
+typedef $$OutboxEntriesTableTableInsertCompanionBuilder
+    = OutboxEntriesTableCompanion Function({
+  Value<int> id,
+  required String entityType,
+  required String entityId,
+  Value<String?> spaceId,
+  required String operation,
+  required String payload,
+  required int updatedAt,
+  required int version,
+  required int createdAt,
+});
+typedef $$OutboxEntriesTableTableUpdateCompanionBuilder
+    = OutboxEntriesTableCompanion Function({
+  Value<int> id,
+  Value<String> entityType,
+  Value<String> entityId,
+  Value<String?> spaceId,
+  Value<String> operation,
+  Value<String> payload,
+  Value<int> updatedAt,
+  Value<int> version,
+  Value<int> createdAt,
+});
+
+class $$OutboxEntriesTableTableTableManager extends RootTableManager<
+    _$LocalDatabase,
+    $OutboxEntriesTableTable,
+    OutboxEntryRow,
+    $$OutboxEntriesTableTableFilterComposer,
+    $$OutboxEntriesTableTableOrderingComposer,
+    $$OutboxEntriesTableTableProcessedTableManager,
+    $$OutboxEntriesTableTableInsertCompanionBuilder,
+    $$OutboxEntriesTableTableUpdateCompanionBuilder> {
+  $$OutboxEntriesTableTableTableManager(
+      _$LocalDatabase db, $OutboxEntriesTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$OutboxEntriesTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer: $$OutboxEntriesTableTableOrderingComposer(
+              ComposerState(db, table)),
+          getChildManagerBuilder: (p) =>
+              $$OutboxEntriesTableTableProcessedTableManager(p),
+          getUpdateCompanionBuilder: ({
+            Value<int> id = const Value.absent(),
+            Value<String> entityType = const Value.absent(),
+            Value<String> entityId = const Value.absent(),
+            Value<String?> spaceId = const Value.absent(),
+            Value<String> operation = const Value.absent(),
+            Value<String> payload = const Value.absent(),
+            Value<int> updatedAt = const Value.absent(),
+            Value<int> version = const Value.absent(),
+            Value<int> createdAt = const Value.absent(),
+          }) =>
+              OutboxEntriesTableCompanion(
+            id: id,
+            entityType: entityType,
+            entityId: entityId,
+            spaceId: spaceId,
+            operation: operation,
+            payload: payload,
+            updatedAt: updatedAt,
+            version: version,
+            createdAt: createdAt,
+          ),
+          getInsertCompanionBuilder: ({
+            Value<int> id = const Value.absent(),
+            required String entityType,
+            required String entityId,
+            Value<String?> spaceId = const Value.absent(),
+            required String operation,
+            required String payload,
+            required int updatedAt,
+            required int version,
+            required int createdAt,
+          }) =>
+              OutboxEntriesTableCompanion.insert(
+            id: id,
+            entityType: entityType,
+            entityId: entityId,
+            spaceId: spaceId,
+            operation: operation,
+            payload: payload,
+            updatedAt: updatedAt,
+            version: version,
+            createdAt: createdAt,
+          ),
+        ));
+}
+
+class $$OutboxEntriesTableTableProcessedTableManager
+    extends ProcessedTableManager<
+        _$LocalDatabase,
+        $OutboxEntriesTableTable,
+        OutboxEntryRow,
+        $$OutboxEntriesTableTableFilterComposer,
+        $$OutboxEntriesTableTableOrderingComposer,
+        $$OutboxEntriesTableTableProcessedTableManager,
+        $$OutboxEntriesTableTableInsertCompanionBuilder,
+        $$OutboxEntriesTableTableUpdateCompanionBuilder> {
+  $$OutboxEntriesTableTableProcessedTableManager(super.$state);
+}
+
+class $$OutboxEntriesTableTableFilterComposer
+    extends FilterComposer<_$LocalDatabase, $OutboxEntriesTableTable> {
+  $$OutboxEntriesTableTableFilterComposer(super.$state);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get entityType => $state.composableBuilder(
+      column: $state.table.entityType,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get entityId => $state.composableBuilder(
+      column: $state.table.entityId,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get spaceId => $state.composableBuilder(
+      column: $state.table.spaceId,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get operation => $state.composableBuilder(
+      column: $state.table.operation,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get createdAt => $state.composableBuilder(
+      column: $state.table.createdAt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$OutboxEntriesTableTableOrderingComposer
+    extends OrderingComposer<_$LocalDatabase, $OutboxEntriesTableTable> {
+  $$OutboxEntriesTableTableOrderingComposer(super.$state);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get entityType => $state.composableBuilder(
+      column: $state.table.entityType,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get entityId => $state.composableBuilder(
+      column: $state.table.entityId,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get spaceId => $state.composableBuilder(
+      column: $state.table.spaceId,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get operation => $state.composableBuilder(
+      column: $state.table.operation,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get updatedAt => $state.composableBuilder(
+      column: $state.table.updatedAt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get version => $state.composableBuilder(
+      column: $state.table.version,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get createdAt => $state.composableBuilder(
+      column: $state.table.createdAt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class _$LocalDatabaseManager {
+  final _$LocalDatabase _db;
+  _$LocalDatabaseManager(this._db);
+  $$SpacesTableTableTableManager get spacesTable =>
+      $$SpacesTableTableTableManager(_db, _db.spacesTable);
+  $$ItemsTableTableTableManager get itemsTable =>
+      $$ItemsTableTableTableManager(_db, _db.itemsTable);
+  $$UsersTableTableTableManager get usersTable =>
+      $$UsersTableTableTableManager(_db, _db.usersTable);
+  $$SpaceMembershipsTableTableTableManager get spaceMembershipsTable =>
+      $$SpaceMembershipsTableTableTableManager(_db, _db.spaceMembershipsTable);
+  $$OutboxEntriesTableTableTableManager get outboxEntriesTable =>
+      $$OutboxEntriesTableTableTableManager(_db, _db.outboxEntriesTable);
+}

--- a/lib/data/remote/models.dart
+++ b/lib/data/remote/models.dart
@@ -1,0 +1,367 @@
+import 'dart:convert';
+
+typedef JsonMap = Map<String, dynamic>;
+
+double _toDouble(dynamic value) {
+  if (value is num) {
+    return value.toDouble();
+  }
+  return double.parse(value.toString());
+}
+
+class RemoteSpace {
+  RemoteSpace({
+    required this.id,
+    required this.name,
+    required this.positionDx,
+    required this.positionDy,
+    required this.sizeWidth,
+    required this.sizeHeight,
+    this.parentId,
+    required this.version,
+    required this.updatedAt,
+    this.isDeleted = false,
+  });
+
+  final String id;
+  final String name;
+  final double positionDx;
+  final double positionDy;
+  final double sizeWidth;
+  final double sizeHeight;
+  final String? parentId;
+  final int version;
+  final DateTime updatedAt;
+  final bool isDeleted;
+
+  JsonMap toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'positionDx': positionDx,
+      'positionDy': positionDy,
+      'sizeWidth': sizeWidth,
+      'sizeHeight': sizeHeight,
+      'parentId': parentId,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'isDeleted': isDeleted,
+    };
+  }
+
+  factory RemoteSpace.fromJson(JsonMap json) {
+    return RemoteSpace(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      positionDx: _toDouble(json['positionDx']),
+      positionDy: _toDouble(json['positionDy']),
+      sizeWidth: _toDouble(json['sizeWidth']),
+      sizeHeight: _toDouble(json['sizeHeight']),
+      parentId: json['parentId'] as String?,
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      isDeleted: json['isDeleted'] as bool? ?? false,
+    );
+  }
+}
+
+class RemoteItem {
+  RemoteItem({
+    required this.id,
+    required this.spaceId,
+    required this.name,
+    required this.description,
+    this.locationSpecification,
+    this.tags,
+    this.imagePath,
+    required this.version,
+    required this.updatedAt,
+    this.isDeleted = false,
+  });
+
+  final String id;
+  final String spaceId;
+  final String name;
+  final String description;
+  final String? locationSpecification;
+  final List<String>? tags;
+  final String? imagePath;
+  final int version;
+  final DateTime updatedAt;
+  final bool isDeleted;
+
+  JsonMap toJson() {
+    return {
+      'id': id,
+      'spaceId': spaceId,
+      'name': name,
+      'description': description,
+      'locationSpecification': locationSpecification,
+      'tags': tags,
+      'imagePath': imagePath,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'isDeleted': isDeleted,
+    };
+  }
+
+  factory RemoteItem.fromJson(JsonMap json) {
+    return RemoteItem(
+      id: json['id'] as String,
+      spaceId: json['spaceId'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String,
+      locationSpecification: json['locationSpecification'] as String?,
+      tags: json['tags'] == null
+          ? null
+          : List<String>.from(json['tags'] as List<dynamic>),
+      imagePath: json['imagePath'] as String?,
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      isDeleted: json['isDeleted'] as bool? ?? false,
+    );
+  }
+}
+
+class RemoteUser {
+  RemoteUser({
+    required this.id,
+    required this.email,
+    this.displayName,
+    this.avatarUrl,
+    required this.isCurrentUser,
+    required this.version,
+    required this.updatedAt,
+    this.isDeleted = false,
+  });
+
+  final String id;
+  final String email;
+  final String? displayName;
+  final String? avatarUrl;
+  final bool isCurrentUser;
+  final int version;
+  final DateTime updatedAt;
+  final bool isDeleted;
+
+  JsonMap toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'displayName': displayName,
+      'avatarUrl': avatarUrl,
+      'isCurrentUser': isCurrentUser,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'isDeleted': isDeleted,
+    };
+  }
+
+  factory RemoteUser.fromJson(JsonMap json) {
+    return RemoteUser(
+      id: json['id'] as String,
+      email: json['email'] as String,
+      displayName: json['displayName'] as String?,
+      avatarUrl: json['avatarUrl'] as String?,
+      isCurrentUser: json['isCurrentUser'] as bool? ?? false,
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      isDeleted: json['isDeleted'] as bool? ?? false,
+    );
+  }
+}
+
+class RemoteMembership {
+  RemoteMembership({
+    required this.spaceId,
+    required this.userId,
+    required this.role,
+    required this.attachmentVisibility,
+    this.joinedAt,
+    required this.version,
+    required this.updatedAt,
+    this.isDeleted = false,
+  });
+
+  final String spaceId;
+  final String userId;
+  final String role;
+  final String attachmentVisibility;
+  final DateTime? joinedAt;
+  final int version;
+  final DateTime updatedAt;
+  final bool isDeleted;
+
+  JsonMap toJson() {
+    return {
+      'spaceId': spaceId,
+      'userId': userId,
+      'role': role,
+      'attachmentVisibility': attachmentVisibility,
+      'joinedAt': joinedAt?.millisecondsSinceEpoch,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'isDeleted': isDeleted,
+    };
+  }
+
+  factory RemoteMembership.fromJson(JsonMap json) {
+    return RemoteMembership(
+      spaceId: json['spaceId'] as String,
+      userId: json['userId'] as String,
+      role: json['role'] as String,
+      attachmentVisibility: json['attachmentVisibility'] as String,
+      joinedAt: json['joinedAt'] == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(json['joinedAt'] as int),
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      isDeleted: json['isDeleted'] as bool? ?? false,
+    );
+  }
+}
+
+class SyncMutation {
+  SyncMutation({
+    required this.entityType,
+    required this.entityId,
+    required this.operation,
+    required this.payload,
+    required this.version,
+    required this.updatedAt,
+    this.spaceId,
+  });
+
+  final String entityType;
+  final String entityId;
+  final String operation;
+  final Map<String, dynamic> payload;
+  final int version;
+  final DateTime updatedAt;
+  final String? spaceId;
+
+  JsonMap toJson() {
+    return {
+      'entityType': entityType,
+      'entityId': entityId,
+      'operation': operation,
+      'payload': payload,
+      'version': version,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'spaceId': spaceId,
+    };
+  }
+
+  factory SyncMutation.fromJson(JsonMap json) {
+    final payloadDynamic = json['payload'];
+    final payload = payloadDynamic is String
+        ? jsonDecode(payloadDynamic) as Map<String, dynamic>
+        : Map<String, dynamic>.from(payloadDynamic as Map<String, dynamic>);
+    return SyncMutation(
+      entityType: json['entityType'] as String,
+      entityId: json['entityId'] as String,
+      operation: json['operation'] as String,
+      payload: payload,
+      version: json['version'] as int,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        json['updatedAt'] as int,
+      ),
+      spaceId: json['spaceId'] as String?,
+    );
+  }
+}
+
+class SyncRequest {
+  SyncRequest({
+    required this.mutations,
+    this.cursor,
+  });
+
+  final List<SyncMutation> mutations;
+  final String? cursor;
+
+  JsonMap toJson() {
+    return {
+      'cursor': cursor,
+      'mutations': mutations.map((mutation) => mutation.toJson()).toList(),
+    };
+  }
+
+  factory SyncRequest.fromJson(JsonMap json) {
+    final mutations = (json['mutations'] as List<dynamic>? ?? const [])
+        .map(
+          (dynamic entry) => SyncMutation.fromJson(
+            Map<String, dynamic>.from(entry as Map),
+          ),
+        )
+        .toList();
+    return SyncRequest(
+      mutations: mutations,
+      cursor: json['cursor'] as String?,
+    );
+  }
+}
+
+class SyncResponse {
+  SyncResponse({
+    required this.spaces,
+    required this.items,
+    required this.users,
+    required this.memberships,
+    this.cursor,
+  });
+
+  final List<RemoteSpace> spaces;
+  final List<RemoteItem> items;
+  final List<RemoteUser> users;
+  final List<RemoteMembership> memberships;
+  final String? cursor;
+
+  JsonMap toJson() {
+    return {
+      'cursor': cursor,
+      'spaces': spaces.map((space) => space.toJson()).toList(),
+      'items': items.map((item) => item.toJson()).toList(),
+      'users': users.map((user) => user.toJson()).toList(),
+      'memberships':
+          memberships.map((member) => member.toJson()).toList(),
+    };
+  }
+
+  factory SyncResponse.fromJson(JsonMap json) {
+    List<T> parseList<T>(String key, T Function(JsonMap json) parser) {
+      final value = json[key];
+      if (value is List) {
+        return value
+            .map((entry) => parser(Map<String, dynamic>.from(entry as Map)))
+            .toList();
+      }
+      return const [];
+    }
+
+    return SyncResponse(
+      cursor: json['cursor'] as String?,
+      spaces: parseList('spaces', RemoteSpace.fromJson),
+      items: parseList('items', RemoteItem.fromJson),
+      users: parseList('users', RemoteUser.fromJson),
+      memberships: parseList('memberships', RemoteMembership.fromJson),
+    );
+  }
+
+  factory SyncResponse.empty() {
+    return SyncResponse(
+      spaces: const [],
+      items: const [],
+      users: const [],
+      memberships: const [],
+    );
+  }
+}

--- a/lib/data/remote/remote_api_client.dart
+++ b/lib/data/remote/remote_api_client.dart
@@ -1,0 +1,15 @@
+import 'remote_api_client_base.dart';
+import 'remote_api_client_stub.dart'
+    if (dart.library.io) 'remote_api_client_impl.dart' as remote_client_impl;
+
+export 'remote_api_client_base.dart';
+
+RemoteApiClient createHttpRemoteApiClient({
+  required String baseUrl,
+  String syncPath = '/sync',
+}) {
+  return remote_client_impl.createHttpRemoteApiClient(
+    baseUrl: baseUrl,
+    syncPath: syncPath,
+  );
+}

--- a/lib/data/remote/remote_api_client_base.dart
+++ b/lib/data/remote/remote_api_client_base.dart
@@ -1,0 +1,16 @@
+import 'models.dart';
+
+abstract class RemoteApiClient {
+  Future<SyncResponse> sync(SyncRequest request);
+  Future<void> dispose();
+}
+
+class NoopRemoteApiClient implements RemoteApiClient {
+  @override
+  Future<SyncResponse> sync(SyncRequest request) async {
+    return SyncResponse.empty();
+  }
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/lib/data/remote/remote_api_client_impl.dart
+++ b/lib/data/remote/remote_api_client_impl.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'models.dart';
+import 'remote_api_client_base.dart';
+
+RemoteApiClient createHttpRemoteApiClient({
+  required String baseUrl,
+  String syncPath = '/sync',
+}) {
+  return _HttpRemoteApiClient(baseUrl: baseUrl, syncPath: syncPath);
+}
+
+class _HttpRemoteApiClient implements RemoteApiClient {
+  _HttpRemoteApiClient({
+    required this.baseUrl,
+    required this.syncPath,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final String baseUrl;
+  final String syncPath;
+  final HttpClient _httpClient;
+
+  Uri get _syncUri {
+    final base = Uri.parse(baseUrl);
+    final pathUri = Uri.parse(syncPath);
+    return base.resolveUri(pathUri);
+  }
+
+  @override
+  Future<SyncResponse> sync(SyncRequest request) async {
+    final uri = _syncUri;
+    final httpRequest = await _httpClient.postUrl(uri);
+    httpRequest.headers.set(HttpHeaders.contentTypeHeader, 'application/json');
+    httpRequest.add(utf8.encode(jsonEncode(request.toJson())));
+    final response = await httpRequest.close();
+    final responseBody = await utf8.decoder.bind(response).join();
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      if (responseBody.trim().isEmpty) {
+        return SyncResponse.empty();
+      }
+      final dynamic decoded = jsonDecode(responseBody);
+      if (decoded is Map<String, dynamic>) {
+        return SyncResponse.fromJson(decoded);
+      }
+      throw const FormatException('Unexpected sync response payload');
+    }
+    throw HttpException(
+      'Failed to sync (${response.statusCode}): $responseBody',
+      uri: uri,
+    );
+  }
+
+  @override
+  Future<void> dispose() async {
+    _httpClient.close();
+  }
+}

--- a/lib/data/remote/remote_api_client_stub.dart
+++ b/lib/data/remote/remote_api_client_stub.dart
@@ -1,0 +1,8 @@
+import 'remote_api_client_base.dart';
+
+RemoteApiClient createHttpRemoteApiClient({
+  required String baseUrl,
+  String syncPath = '/sync',
+}) {
+  return NoopRemoteApiClient();
+}

--- a/lib/data/spaces_repository.dart
+++ b/lib/data/spaces_repository.dart
@@ -1,0 +1,20 @@
+import '../models/space_model.dart';
+
+import 'local_database.dart';
+
+class SpacesRepository implements SpaceStorage {
+  SpacesRepository({LocalDatabase? database})
+      : _database = database ?? LocalDatabase();
+
+  final LocalDatabase _database;
+
+  @override
+  Future<void> saveSpaces(List<SpaceModel> spaces) {
+    return _database.replaceAllSpaces(spaces);
+  }
+
+  @override
+  Future<List<SpaceModel>> loadSpaces() {
+    return _database.loadSpaces();
+  }
+}

--- a/lib/data/sync_service.dart
+++ b/lib/data/sync_service.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'local_database.dart';
+import 'remote/models.dart';
+import 'remote/remote_api_client.dart';
+
+typedef ConnectivityCheck = Future<bool> Function();
+
+class SyncService {
+  SyncService({
+    required LocalDatabase database,
+    required RemoteApiClient apiClient,
+    Duration pollInterval = const Duration(minutes: 5),
+    int maxBatchSize = 50,
+    ConnectivityCheck? connectivityCheck,
+  })  : _database = database,
+        _apiClient = apiClient,
+        _pollInterval = pollInterval,
+        _maxBatchSize = maxBatchSize,
+        _connectivityCheck = connectivityCheck ?? _alwaysConnected;
+
+  final LocalDatabase _database;
+  final RemoteApiClient _apiClient;
+  final Duration _pollInterval;
+  final int _maxBatchSize;
+  final ConnectivityCheck _connectivityCheck;
+
+  Timer? _timer;
+  bool _isRunning = false;
+  bool _isSyncing = false;
+  String? _cursor;
+
+  static Future<bool> _alwaysConnected() async => true;
+
+  bool get isRunning => _isRunning;
+
+  void start() {
+    if (_isRunning) {
+      return;
+    }
+    _isRunning = true;
+    _timer = Timer.periodic(_pollInterval, (_) {
+      unawaited(syncNow());
+    });
+    unawaited(syncNow());
+  }
+
+  Future<void> syncNow() async {
+    if (_isSyncing) {
+      return;
+    }
+    _isSyncing = true;
+    try {
+      if (!await _connectivityCheck()) {
+        return;
+      }
+      var hasMore = true;
+      while (hasMore) {
+        final pending = await _database.getPendingMutations(
+          limit: _maxBatchSize,
+        );
+        final request = SyncRequest(
+          mutations: pending.map((mutation) => mutation.toSyncMutation()).toList(),
+          cursor: _cursor,
+        );
+        final response = await _apiClient.sync(request);
+        await _database.applyRemoteChanges(response);
+        if (pending.isNotEmpty) {
+          await _database.markMutationsProcessed(
+            pending.map((mutation) => mutation.id).toList(),
+          );
+        }
+        _cursor = response.cursor ?? _cursor;
+        hasMore = pending.length == _maxBatchSize;
+        if (!hasMore) {
+          break;
+        }
+      }
+    } catch (error, stackTrace) {
+      debugPrint('SyncService error: $error\n$stackTrace');
+    } finally {
+      _isSyncing = false;
+    }
+  }
+
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _isRunning = false;
+  }
+
+  Future<void> dispose() async {
+    stop();
+    await _apiClient.dispose();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,23 +2,54 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import 'data/local_database.dart';
+import 'data/remote/remote_api_client.dart';
+import 'data/spaces_repository.dart';
+import 'data/sync_service.dart';
 import 'models/space_model.dart';
 import 'pages/home.dart';
 import 'theme/app_theme.dart';
 import 'theme/theme_controller.dart';
 
-void main() async {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  final database = LocalDatabase();
+  final repository = SpacesRepository(database: database);
+  SpaceModel.configureStorage(repository);
   await SpaceModel.loadItems();
 
+  const syncBaseUrl = String.fromEnvironment(
+    'FIND_IT_SYNC_URL',
+    defaultValue: '',
+  );
+  final RemoteApiClient remoteApiClient = syncBaseUrl.isEmpty
+      ? NoopRemoteApiClient()
+      : createHttpRemoteApiClient(baseUrl: syncBaseUrl);
+
+  final syncService = SyncService(
+    database: database,
+    apiClient: remoteApiClient,
+  );
+
   final themeController = ThemeController();
-  runApp(FindItApp(themeController: themeController));
+  runApp(
+    FindItApp(
+      themeController: themeController,
+      syncService: syncService,
+    ),
+  );
 }
 
 class FindItApp extends StatefulWidget {
-  const FindItApp({super.key, required this.themeController});
+  const FindItApp({
+    super.key,
+    required this.themeController,
+    this.syncService,
+  });
 
   final ThemeController themeController;
+  final SyncService? syncService;
 
   @override
   State<FindItApp> createState() => _FindItAppState();
@@ -29,11 +60,13 @@ class _FindItAppState extends State<FindItApp> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    widget.syncService?.start();
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    widget.syncService?.dispose();
     super.dispose();
   }
 

--- a/lib/models/item_model.dart
+++ b/lib/models/item_model.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
 import 'space_model.dart';
 
 class ItemModel {
+  final String id;
   String name;
   String description;
   String? locationSpecification;
@@ -45,16 +48,18 @@ class ItemModel {
   ];
 
   ItemModel({
+    String? id,
     required this.name,
     required this.description,
     this.locationSpecification,
     this.tags,
     this.imagePath,
     this.parent,
-  });
+  }) : id = id ?? const Uuid().v4();
 
   factory ItemModel.fromJson(Map<String, dynamic> json) {
     return ItemModel(
+      id: json['id'],
       name: json['name'],
       description: json['description'],
       locationSpecification: json['locationSpecification'],
@@ -65,6 +70,7 @@ class ItemModel {
 
   Map<String, dynamic> toJson() {
     return {
+      'id': id,
       'name': name,
       'description': description,
       'locationSpecification': locationSpecification,

--- a/lib/models/space_member.dart
+++ b/lib/models/space_member.dart
@@ -1,0 +1,73 @@
+import 'user_profile.dart';
+
+enum SpaceRole {
+  owner,
+  editor,
+  viewer,
+}
+
+enum AttachmentVisibility {
+  shared,
+  private,
+}
+
+SpaceRole spaceRoleFromName(String value) {
+  return SpaceRole.values.firstWhere(
+    (role) => role.name == value,
+    orElse: () => SpaceRole.viewer,
+  );
+}
+
+AttachmentVisibility attachmentVisibilityFromName(String value) {
+  return AttachmentVisibility.values.firstWhere(
+    (visibility) => visibility.name == value,
+    orElse: () => AttachmentVisibility.shared,
+  );
+}
+
+class SpaceMember {
+  SpaceMember({
+    required this.user,
+    required this.role,
+    this.joinedAt,
+    this.defaultAttachmentVisibility = AttachmentVisibility.shared,
+  });
+
+  final UserProfile user;
+  final SpaceRole role;
+  final DateTime? joinedAt;
+  final AttachmentVisibility defaultAttachmentVisibility;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'user': user.toJson(),
+      'role': role.name,
+      'joinedAt': joinedAt?.toIso8601String(),
+      'attachmentVisibility': defaultAttachmentVisibility.name,
+    };
+  }
+
+  factory SpaceMember.fromJson(Map<String, dynamic> json) {
+    final dynamic userJson = json['user'];
+    final UserProfile user;
+    if (userJson is Map<String, dynamic>) {
+      user = UserProfile.fromJson(userJson);
+    } else {
+      user = UserProfile(
+        id: json['userId'] as String?,
+        email: (json['email'] ?? '') as String,
+      );
+    }
+    return SpaceMember(
+      user: user,
+      role: spaceRoleFromName(json['role'] as String? ?? SpaceRole.viewer.name),
+      joinedAt: json['joinedAt'] is String
+          ? DateTime.tryParse(json['joinedAt'] as String)
+          : null,
+      defaultAttachmentVisibility: attachmentVisibilityFromName(
+        json['attachmentVisibility'] as String? ??
+            AttachmentVisibility.shared.name,
+      ),
+    );
+  }
+}

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,53 @@
+import 'package:uuid/uuid.dart';
+
+class UserProfile {
+  UserProfile({
+    String? id,
+    required this.email,
+    this.displayName,
+    this.avatarUrl,
+    this.isCurrentUser = false,
+  }) : id = id ?? const Uuid().v4();
+
+  final String id;
+  final String email;
+  final String? displayName;
+  final String? avatarUrl;
+  final bool isCurrentUser;
+
+  UserProfile copyWith({
+    String? id,
+    String? email,
+    String? displayName,
+    String? avatarUrl,
+    bool? isCurrentUser,
+  }) {
+    return UserProfile(
+      id: id ?? this.id,
+      email: email ?? this.email,
+      displayName: displayName ?? this.displayName,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      isCurrentUser: isCurrentUser ?? this.isCurrentUser,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'displayName': displayName,
+      'avatarUrl': avatarUrl,
+      'isCurrentUser': isCurrentUser,
+    };
+  }
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    return UserProfile(
+      id: json['id'] as String?,
+      email: json['email'] as String,
+      displayName: json['displayName'] as String?,
+      avatarUrl: json['avatarUrl'] as String?,
+      isCurrentUser: json['isCurrentUser'] as bool? ?? false,
+    );
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
+  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  sqlite3_flutter_libs
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,8 +7,12 @@ import Foundation
 
 import file_selector_macos
 import path_provider_foundation
+import sqflite_darwin
+import sqlite3_flutter_libs
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "4897882604d919befd350648c7f91926a9d5de99e67b455bf0917cc2362f4bb8"
+      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
       url: "https://pub.dev"
     source: hosted
-    version: "47.0.0"
+    version: "61.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "690e335554a8385bc9d787117d9eb52c0c03ee207a607e593de3c9d71b1cfe80"
+      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "5.13.0"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      sha256: c1d5f167683de03d5ab6c3b53fc9aeefc5d59476e7810ba7bbddff50c6f4392d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.2"
   args:
     dependency: transitive
     description:
@@ -69,12 +77,12 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "687cf90a3951affac1bd5f9ecb5e3e90b60487f3d9cdc359bb310f8876bb02a6"
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.10"
+    version: "2.4.2"
   build_runner:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: build_runner
       sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
@@ -113,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -121,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -185,6 +209,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
+  drift:
+    dependency: "direct main"
+    description:
+      name: drift
+      sha256: "6acedc562ffeed308049f78fb1906abad3d65714580b6745441ee6d50ec564cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.18.0"
+  drift_dev:
+    dependency: "direct dev"
+    description:
+      name: drift_dev
+      sha256: d9b020736ea85fff1568699ce18b89fabb3f0f042e8a7a05e84a3ec20d39acde
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -444,18 +484,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -492,18 +532,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -521,7 +561,7 @@ packages:
     source: hosted
     version: "2.1.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
@@ -577,7 +617,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
@@ -640,6 +680,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   remove_diacritic:
     dependency: "direct main"
     description:
@@ -669,6 +717,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   source_span:
     dependency: transitive
     description:
@@ -677,6 +733,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sqflite:
+    dependency: "direct main"
+    description:
+      name: sqflite
+      sha256: "2d7299468485dca85efeeadf5d38986909c5eb0cd71fd3db2c2f000e6c9454bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "78f489aab276260cdd26676d2169446c7ecd3484bbd5fead4ca14f3ed4dd9ee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "761b9740ecbd4d3e66b8916d784e581861fd3c3553eda85e167bc49fdb68f709"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4+6"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "22adfd9a2c7d634041e96d6241e6e1c8138ca6817018afc5d443fef91dcefa9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1+1"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: fde692580bee3379374af1f624eb3e113ab2865ecb161dbe2d8ac2de9735dbdb
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.5"
+  sqlite3_flutter_libs:
+    dependency: "direct main"
+    description:
+      name: sqlite3_flutter_libs
+      sha256: "2b03273e71867a8a4d030861fc21706200debe5c5858a4b9e58f4a1c129586a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.39"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      sha256: ade9a67fd70d0369329ed3373208de7ebd8662470e8c396fc8d0d60f9acdfc9f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.36.0"
   stack_trace:
     dependency: transitive
     description:
@@ -709,6 +829,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0+3"
   term_glyph:
     dependency: transitive
     description:
@@ -721,10 +849,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   timing:
     dependency: transitive
     description:
@@ -741,6 +869,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  uuid:
+    dependency: "direct main"
+    description:
+      name: uuid
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
@@ -753,10 +889,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -769,10 +905,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "0.5.1"
   web_socket:
     dependency: transitive
     description:
@@ -822,5 +958,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.4 <3.0.0'
+  sdk: '>=2.18.4 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -38,11 +38,15 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter_svg: ^1.1.6
   path_provider: ^2.1.3
-  build_runner: ^2.1.4
   remove_diacritic: ^0.9.0
   image_picker: ^0.8.4+4
   file_picker: ^5.0.0
   intl: ^0.19.0
+  path: ^1.8.3
+  uuid: ^3.0.7
+  sqflite: ^2.2.8
+  drift: ^2.4.0
+  sqlite3_flutter_libs: ^0.5.20
 
 dev_dependencies:
   flutter_test:
@@ -54,6 +58,9 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
+  build_runner: ^2.1.4
+  drift_dev: ^2.4.0
+  path_provider_platform_interface: ^2.0.6
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/data/local_database_test.dart
+++ b/test/data/local_database_test.dart
@@ -1,0 +1,192 @@
+import 'dart:io';
+
+import 'package:find_it/data/local_database.dart';
+import 'package:find_it/models/item_model.dart';
+import 'package:find_it/models/space_member.dart';
+import 'package:find_it/models/space_model.dart';
+import 'package:find_it/models/user_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this._documentsPath);
+
+  final String _documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => _documentsPath;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late Directory tempDir;
+  late PathProviderPlatform originalPlatform;
+  late LocalDatabase database;
+
+  setUp(() async {
+    originalPlatform = PathProviderPlatform.instance;
+    tempDir = await Directory.systemTemp.createTemp('local_database_test');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    database = LocalDatabase();
+  });
+
+  tearDown(() async {
+    await database.dispose();
+    PathProviderPlatform.instance = originalPlatform;
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('round-trips spaces and items while restoring parents', () async {
+    final owner = UserProfile(
+      id: 'user-owner',
+      email: 'owner@example.com',
+      displayName: 'Owner',
+      isCurrentUser: true,
+    );
+
+    final viewer = UserProfile(
+      id: 'user-viewer',
+      email: 'viewer@example.com',
+      displayName: 'Viewer',
+    );
+
+    final toolbox = SpaceModel(
+      name: 'Toolbox',
+      position: const Offset(5, 8),
+      size: const Size(60, 40),
+      items: [
+        ItemModel(name: 'Hammer', description: 'Claw hammer'),
+      ],
+      collaborators: [
+        SpaceMember(
+          user: owner,
+          role: SpaceRole.editor,
+          defaultAttachmentVisibility: AttachmentVisibility.private,
+        ),
+      ],
+    );
+
+    final garage = SpaceModel(
+      name: 'Garage',
+      position: const Offset(1, 2),
+      size: const Size(200, 150),
+      mySpaces: [toolbox],
+      items: [
+        ItemModel(name: 'Bike', description: 'Mountain bike'),
+      ],
+      collaborators: [
+        SpaceMember(
+          user: owner,
+          role: SpaceRole.owner,
+          joinedAt: DateTime.utc(2023, 1, 10),
+        ),
+        SpaceMember(
+          user: viewer,
+          role: SpaceRole.viewer,
+          defaultAttachmentVisibility: AttachmentVisibility.private,
+        ),
+      ],
+    );
+
+    await database.replaceAllSpaces([garage]);
+
+    final dbFile = File(p.join(tempDir.path, 'spaces.db'));
+    expect(dbFile.existsSync(), isTrue);
+
+    final loaded = await database.loadSpaces();
+    expect(loaded, hasLength(1));
+
+    final loadedGarage = loaded.single;
+    expect(loadedGarage.name, garage.name);
+    expect(loadedGarage.position, garage.position);
+    expect(loadedGarage.size, garage.size);
+    expect(loadedGarage.items, hasLength(1));
+    expect(loadedGarage.items.single.name, 'Bike');
+    expect(loadedGarage.items.single.parent, same(loadedGarage));
+
+    expect(loadedGarage.collaborators, hasLength(2));
+    final loadedOwner = loadedGarage.collaborators
+        .firstWhere((member) => member.role == SpaceRole.owner);
+    expect(loadedOwner.user.email, owner.email);
+    expect(loadedOwner.user.isCurrentUser, isTrue);
+    expect(loadedOwner.joinedAt?.toUtc(), DateTime.utc(2023, 1, 10));
+    expect(
+        loadedOwner.defaultAttachmentVisibility, AttachmentVisibility.shared);
+
+    final loadedViewer = loadedGarage.collaborators
+        .firstWhere((member) => member.role == SpaceRole.viewer);
+    expect(loadedViewer.user.email, viewer.email);
+    expect(
+        loadedViewer.defaultAttachmentVisibility, AttachmentVisibility.private);
+
+    final loadedToolbox = loadedGarage.mySpaces.single;
+    expect(loadedToolbox.name, toolbox.name);
+    expect(loadedToolbox.parent, same(loadedGarage));
+    expect(loadedToolbox.position, toolbox.position);
+    expect(loadedToolbox.size, toolbox.size);
+    expect(loadedToolbox.items.single.name, 'Hammer');
+    expect(loadedToolbox.items.single.parent, same(loadedToolbox));
+    expect(loadedToolbox.collaborators, hasLength(1));
+    expect(loadedToolbox.collaborators.single.role, SpaceRole.editor);
+    expect(loadedToolbox.collaborators.single.defaultAttachmentVisibility,
+        AttachmentVisibility.private);
+  });
+
+  test('replaceAllSpaces enqueues mutations only when data changes', () async {
+    final owner = UserProfile(
+      id: 'owner',
+      email: 'owner@example.com',
+      isCurrentUser: true,
+    );
+
+    final drawer = SpaceModel(
+      name: 'Drawer',
+      items: [
+        ItemModel(name: 'Keys', description: 'Car keys'),
+      ],
+      collaborators: [
+        SpaceMember(
+          user: owner,
+          role: SpaceRole.owner,
+        ),
+      ],
+    );
+
+    final hallway = SpaceModel(
+      name: 'Hallway',
+      mySpaces: [drawer],
+    );
+    hallway.assignParents();
+
+    await database.replaceAllSpaces([hallway]);
+    final initialMutations = await database.getPendingMutations();
+    expect(initialMutations, isNotEmpty);
+    await database.markMutationsProcessed(
+      initialMutations.map((mutation) => mutation.id).toList(),
+    );
+
+    final unchangedCopy = SpaceModel.fromJson(hallway.toJson());
+    unchangedCopy.assignParents();
+    await database.replaceAllSpaces([unchangedCopy]);
+    final noChangeMutations = await database.getPendingMutations();
+    expect(noChangeMutations, isEmpty);
+
+    final renamed = SpaceModel.fromJson(hallway.toJson());
+    renamed.name = 'Renovated Hallway';
+    renamed.assignParents();
+    await database.replaceAllSpaces([renamed]);
+    final updatedMutations = await database.getPendingMutations();
+    expect(
+      updatedMutations.where((mutation) =>
+          mutation.entityType == 'space' && mutation.operation == 'upsert'),
+      isNotEmpty,
+    );
+    await database.markMutationsProcessed(
+      updatedMutations.map((mutation) => mutation.id).toList(),
+    );
+  });
+}

--- a/test/data/sync_service_test.dart
+++ b/test/data/sync_service_test.dart
@@ -1,0 +1,147 @@
+import 'dart:io';
+
+import 'package:find_it/data/local_database.dart';
+import 'package:find_it/data/remote/models.dart';
+import 'package:find_it/data/remote/remote_api_client.dart';
+import 'package:find_it/data/sync_service.dart';
+import 'package:find_it/models/item_model.dart';
+import 'package:find_it/models/space_member.dart';
+import 'package:find_it/models/space_model.dart';
+import 'package:find_it/models/user_profile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this._documentsPath);
+
+  final String _documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => _documentsPath;
+}
+
+class FakeRemoteApiClient implements RemoteApiClient {
+  FakeRemoteApiClient({this.handler});
+
+  SyncResponse Function(SyncRequest request)? handler;
+  final List<SyncRequest> capturedRequests = [];
+
+  @override
+  Future<SyncResponse> sync(SyncRequest request) async {
+    capturedRequests.add(request);
+    if (handler != null) {
+      return handler!(request);
+    }
+    return SyncResponse.empty();
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late Directory tempDir;
+  late PathProviderPlatform originalPlatform;
+  late LocalDatabase database;
+  late FakeRemoteApiClient remoteApiClient;
+  late SyncService syncService;
+
+  setUp(() async {
+    originalPlatform = PathProviderPlatform.instance;
+    tempDir = await Directory.systemTemp.createTemp('sync_service_test');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    database = LocalDatabase();
+    remoteApiClient = FakeRemoteApiClient();
+    syncService = SyncService(
+      database: database,
+      apiClient: remoteApiClient,
+      pollInterval: const Duration(minutes: 10),
+    );
+  });
+
+  tearDown(() async {
+    await syncService.dispose();
+    await database.dispose();
+    PathProviderPlatform.instance = originalPlatform;
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('syncNow flushes outbox mutations and applies remote updates', () async {
+    final owner = UserProfile(
+      id: 'owner-user',
+      email: 'owner@example.com',
+      isCurrentUser: true,
+    );
+
+    final closet = SpaceModel(
+      name: 'Closet',
+      items: [
+        ItemModel(name: 'Hat', description: 'Sun hat'),
+      ],
+      collaborators: [
+        SpaceMember(user: owner, role: SpaceRole.owner),
+      ],
+    );
+    closet.assignParents();
+
+    await database.replaceAllSpaces([closet]);
+    final pendingBefore = await database.getPendingMutations();
+    expect(pendingBefore, isNotEmpty);
+
+    final remoteNewItem = RemoteItem(
+      id: 'remote-item-1',
+      spaceId: closet.id,
+      name: 'Scarf',
+      description: 'Wool scarf',
+      version: 1,
+      updatedAt: DateTime.now().toUtc(),
+      isDeleted: false,
+    );
+
+    final remoteSpace = RemoteSpace(
+      id: closet.id,
+      name: closet.name,
+      positionDx: closet.position.dx,
+      positionDy: closet.position.dy,
+      sizeWidth: closet.size.width,
+      sizeHeight: closet.size.height,
+      parentId: null,
+      version: 1,
+      updatedAt: DateTime.now().toUtc(),
+      isDeleted: false,
+    );
+
+    remoteApiClient.handler = (request) {
+      expect(request.mutations, isNotEmpty);
+      return SyncResponse(
+        spaces: [remoteSpace],
+        items: [remoteNewItem],
+        users: const [],
+        memberships: const [],
+        cursor: 'cursor-1',
+      );
+    };
+
+    await syncService.syncNow();
+
+    final pendingAfter = await database.getPendingMutations();
+    expect(pendingAfter, isEmpty);
+
+    final loadedSpaces = await database.loadSpaces();
+    expect(loadedSpaces, hasLength(1));
+    final loadedCloset = loadedSpaces.single;
+    expect(loadedCloset.items, hasLength(2));
+    expect(
+      loadedCloset.items.map((item) => item.name),
+      containsAll(['Hat', 'Scarf']),
+    );
+
+    final dbFile = File(p.join(tempDir.path, 'spaces.db'));
+    expect(dbFile.existsSync(), isTrue);
+  });
+}

--- a/test/space_model_test.dart
+++ b/test/space_model_test.dart
@@ -1,10 +1,14 @@
-import 'dart:convert';
 import 'dart:io';
 
+import 'package:find_it/data/local_database.dart';
+import 'package:find_it/data/spaces_repository.dart';
 import 'package:find_it/models/item_model.dart';
+import 'package:find_it/models/space_member.dart';
 import 'package:find_it/models/space_model.dart';
+import 'package:find_it/models/user_profile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
@@ -18,7 +22,6 @@ class _FakePathProviderPlatform extends PathProviderPlatform {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-
   late PathProviderPlatform originalPlatform;
 
   setUp(() {
@@ -32,6 +35,12 @@ void main() {
 
   group('SpaceModel serialization', () {
     test('toJson/fromJson preserves hierarchy and parents', () {
+      final owner = UserProfile(
+        id: 'user-owner',
+        email: 'owner@example.com',
+        displayName: 'Owner',
+      );
+
       final closet = SpaceModel(
         name: 'Closet',
         position: const Offset(10, 20),
@@ -55,6 +64,13 @@ void main() {
             description: 'Running shoes',
           ),
         ],
+        collaborators: [
+          SpaceMember(
+            user: owner,
+            role: SpaceRole.owner,
+            joinedAt: DateTime.utc(2023, 4, 5),
+          ),
+        ],
       );
 
       final encoded = hallway.toJson();
@@ -65,6 +81,11 @@ void main() {
       expect(decoded.size, hallway.size);
       expect(decoded.mySpaces, hasLength(1));
       expect(decoded.items, hasLength(1));
+      expect(decoded.collaborators, hasLength(1));
+      expect(decoded.collaborators.single.user.email, owner.email);
+      expect(decoded.collaborators.single.role, SpaceRole.owner);
+      expect(decoded.collaborators.single.joinedAt?.toUtc(),
+          DateTime.utc(2023, 4, 5));
 
       final decodedCloset = decoded.mySpaces.single;
       expect(decodedCloset.name, closet.name);
@@ -118,9 +139,12 @@ void main() {
       expect(drawerItem.parent, same(assignedDrawer));
     });
 
-    test('saveItems and loadItems persist spaces to disk', () async {
+    test('saveItems and loadItems persist spaces via sqlite storage', () async {
       final tempDir = await Directory.systemTemp.createTemp('find_it_test');
       PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+
+      final database = LocalDatabase();
+      SpaceModel.configureStorage(SpacesRepository(database: database));
 
       final deskDrawer = SpaceModel(
         name: 'Desk drawer',
@@ -140,14 +164,11 @@ void main() {
       SpaceModel.currentSpaces = [office];
       office.assignParents();
 
-      await SpaceModel.saveItems();
+      final success = await SpaceModel.saveItems();
+      expect(success, isTrue);
 
-      final savedFile = File('${tempDir.path}/data.json');
-      expect(savedFile.existsSync(), isTrue);
-
-      final dynamic savedJson = jsonDecode(await savedFile.readAsString());
-      expect(savedJson, isA<List>());
-      expect(savedJson, hasLength(1));
+      final savedDatabase = File(p.join(tempDir.path, 'spaces.db'));
+      expect(savedDatabase.existsSync(), isTrue);
 
       SpaceModel.currentSpaces = [];
 
@@ -164,6 +185,7 @@ void main() {
       expect(loadedDrawer.items.single.name, 'Notebook');
       expect(loadedDrawer.items.single.parent, same(loadedDrawer));
 
+      await database.dispose();
       await tempDir.delete(recursive: true);
     });
   });

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_windows/file_selector_windows.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
+  sqlite3_flutter_libs
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary
- migrate `LocalDatabase` to a drift schema backed by `NativeDatabase`, defining tables for spaces, items, users, memberships, and outbox metadata while reimplementing persistence, outbox, and remote merge flows with generated companions
- refresh integration tests to initialize the drift-backed storage and path-provider stubs, keeping sync behaviour expectations intact
- add the drift/sqlite3 dependencies and register the sqlite3 runtime plugins for desktop platforms
- surface the new collaborator metadata with a room-page bottom sheet and repair the remote API client alias so the drift build compiles again

## Testing
- `flutter test test/data/local_database_test.dart test/data/sync_service_test.dart test/space_model_test.dart` *(fails: Flutter SDK unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d137b0eebc832a87f99cdcbf9a2ccd