### PR TITLE
Fix sqlite init and gate sync on remote config

### DIFF
--- a/lib/data/local_database.dart
+++ b/lib/data/local_database.dart
@@ -8,6 +8,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/widgets.dart' show Offset, Size;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:sqlite3_flutter_libs/sqlite3_flutter_libs.dart';
 
 import '../models/item_model.dart';
 import '../models/space_member.dart';
@@ -21,6 +22,7 @@ const _dbName = 'spaces.db';
 
 LazyDatabase _openConnection() {
   return LazyDatabase(() async {
+    await applyWorkaroundToOpenSqlite3OnOldAndroidVersions();
     final directory = await getApplicationDocumentsDirectory();
     final file = File(p.join(directory.path, _dbName));
     return NativeDatabase(file, logStatements: false);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,14 +23,14 @@ Future<void> main() async {
     'FIND_IT_SYNC_URL',
     defaultValue: '',
   );
-  final RemoteApiClient remoteApiClient = syncBaseUrl.isEmpty
-      ? NoopRemoteApiClient()
-      : createHttpRemoteApiClient(baseUrl: syncBaseUrl);
-
-  final syncService = SyncService(
-    database: database,
-    apiClient: remoteApiClient,
-  );
+  SyncService? syncService;
+  if (syncBaseUrl.isNotEmpty) {
+    final remoteApiClient = createHttpRemoteApiClient(baseUrl: syncBaseUrl);
+    syncService = SyncService(
+      database: database,
+      apiClient: remoteApiClient,
+    );
+  }
 
   final themeController = ThemeController();
   runApp(


### PR DESCRIPTION
## Summary
- ensure the bundled sqlite library is loaded before opening the Drift database so Android builds can launch
- only create the sync service when a remote endpoint is configured to keep offline mutations queued

## Testing
- Not run (Flutter SDK not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3c5f17310832a82ecc9be2d8f2952