### PR TITLE
Fix sqlite loading and complete sync plumbing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,9 @@ Future<void> main() async {
   final syncService = SyncService(
     database: database,
     apiClient: remoteApiClient,
+    onRemoteUpdate: () async {
+      await SpaceModel.loadItems();
+    },
   );
 
   final themeController = ThemeController();

--- a/lib/models/space_model.dart
+++ b/lib/models/space_model.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:path_provider/path_provider.dart';
@@ -22,6 +23,7 @@ class SpaceModel {
 
   static List<SpaceModel> currentSpaces = [];
   static SpaceStorage? _storage;
+  static final ValueNotifier<int> dataVersion = ValueNotifier<int>(0);
 
   static void configureStorage(SpaceStorage storage) {
     _storage = storage;
@@ -244,9 +246,11 @@ class SpaceModel {
         space.assignParents();
       }
       debugPrint('items loaded');
+      _notifyDataChanged();
     } catch (e, stackTrace) {
       debugPrint('Failed to load items: $e\n$stackTrace');
       currentSpaces = [];
+      _notifyDataChanged();
     }
   }
 
@@ -277,6 +281,10 @@ class SpaceModel {
       debugPrint('Failed to load legacy items: $e\n$stackTrace');
       return [];
     }
+  }
+
+  static void _notifyDataChanged() {
+    dataVersion.value = dataVersion.value + 1;
   }
 }
 

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -19,6 +19,26 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  late final VoidCallback _spacesListener;
+
+  @override
+  void initState() {
+    super.initState();
+    _spacesListener = () {
+      if (!mounted) {
+        return;
+      }
+      setState(() {});
+    };
+    SpaceModel.dataVersion.addListener(_spacesListener);
+  }
+
+  @override
+  void dispose() {
+    SpaceModel.dataVersion.removeListener(_spacesListener);
+    super.dispose();
+  }
+
   Future<void> _refreshSpaces() async {
     await SpaceModel.loadItems();
     if (!mounted) return;


### PR DESCRIPTION
## Summary
- ensure the bundled sqlite3 library loads on Android by importing sqlite3_flutter_libs and applying the native workaround
- persist the remote sync cursor, expose helpers for sync state, and allow the sync service to refresh local data after remote updates
- notify the UI when spaces are reloaded so remote changes surface automatically, and extend tests to cover the new sync behaviour

## Testing
- `flutter test` *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c5f17310832a82ecc9be2d8f2952