### PR TITLE
Fix sqlite initialization and enforce referential integrity

### DIFF
--- a/lib/data/local_database.dart
+++ b/lib/data/local_database.dart
@@ -203,6 +203,9 @@ class LocalDatabase extends _$LocalDatabase {
             await m.createTable(outboxEntriesTable);
           }
         },
+        beforeOpen: (details) async {
+          await customStatement('PRAGMA foreign_keys = ON;');
+        },
       );
 
   Future<void> replaceAllSpaces(List<SpaceModel> spaces) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:sqlite3_flutter_libs/sqlite3_flutter_libs.dart';
 
 import 'data/local_database.dart';
 import 'data/remote/remote_api_client.dart';
@@ -13,6 +14,8 @@ import 'theme/theme_controller.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  await applyWorkaroundToOpenSqlite3OnOldAndroidVersions();
 
   final database = LocalDatabase();
   final repository = SpacesRepository(database: database);


### PR DESCRIPTION
## Summary
- ensure the sqlite3 dynamic library is loaded on Android before the Drift database is opened
- enable SQLite foreign key constraints when opening the local database so cascade deletes work during sync

## Testing
- not run (Flutter tooling is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d3c5f17310832a82ecc9be2d8f2952