### PR TITLE
Fix sqlite loading and persist sync cursor

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,7 +25,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace = "com.example.find_it"
-    compileSdk = flutter.compileSdkVersion
+    compileSdk = 35
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
@@ -39,7 +39,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = flutter.minSdkVersion
-        targetSdk = flutter.targetSdkVersion
+        targetSdk = 35
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="find_it"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:extractNativeLibs="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/data/local_database.dart
+++ b/lib/data/local_database.dart
@@ -910,13 +910,18 @@ class LocalDatabase extends _$LocalDatabase {
     await (delete(outboxEntriesTable)..where((tbl) => tbl.id.isIn(ids))).go();
   }
 
-  Future<void> applyRemoteChanges(SyncResponse response) async {
+  Future<bool> applyRemoteChanges(SyncResponse response) async {
+    var changed = false;
     await transaction(() async {
-      await _applyRemoteUsers(response.users);
-      await _applyRemoteSpaces(response.spaces);
-      await _applyRemoteItems(response.items);
-      await _applyRemoteMemberships(response.memberships);
+      final usersChanged = await _applyRemoteUsers(response.users);
+      final spacesChanged = await _applyRemoteSpaces(response.spaces);
+      final itemsChanged = await _applyRemoteItems(response.items);
+      final membershipsChanged =
+          await _applyRemoteMemberships(response.memberships);
+      changed =
+          usersChanged || spacesChanged || itemsChanged || membershipsChanged;
     });
+    return changed;
   }
 
   Future<void> saveSyncCursor(String? cursor) async {
@@ -934,7 +939,8 @@ class LocalDatabase extends _$LocalDatabase {
     return row?.readNullable<String>('cursor');
   }
 
-  Future<void> _applyRemoteUsers(List<RemoteUser> users) async {
+  Future<bool> _applyRemoteUsers(List<RemoteUser> users) async {
+    var changed = false;
     for (final user in users) {
       final existing = await (select(usersTable)
             ..where((tbl) => tbl.id.equals(user.id)))
@@ -962,14 +968,18 @@ class LocalDatabase extends _$LocalDatabase {
           data.copyWith(id: Value(user.id)),
           mode: InsertMode.insertOrReplace,
         );
+        changed = true;
       } else {
         await (update(usersTable)..where((tbl) => tbl.id.equals(user.id)))
             .write(data);
+        changed = true;
       }
     }
+    return changed;
   }
 
-  Future<void> _applyRemoteSpaces(List<RemoteSpace> spaces) async {
+  Future<bool> _applyRemoteSpaces(List<RemoteSpace> spaces) async {
+    var changed = false;
     for (final space in spaces) {
       final existing = await (select(spacesTable)
             ..where((tbl) => tbl.id.equals(space.id)))
@@ -999,14 +1009,18 @@ class LocalDatabase extends _$LocalDatabase {
           data.copyWith(id: Value(space.id)),
           mode: InsertMode.insertOrReplace,
         );
+        changed = true;
       } else {
         await (update(spacesTable)..where((tbl) => tbl.id.equals(space.id)))
             .write(data);
+        changed = true;
       }
     }
+    return changed;
   }
 
-  Future<void> _applyRemoteItems(List<RemoteItem> items) async {
+  Future<bool> _applyRemoteItems(List<RemoteItem> items) async {
+    var changed = false;
     for (final item in items) {
       final existing = await (select(itemsTable)
             ..where((tbl) => tbl.id.equals(item.id)))
@@ -1036,15 +1050,19 @@ class LocalDatabase extends _$LocalDatabase {
           data.copyWith(id: Value(item.id)),
           mode: InsertMode.insertOrReplace,
         );
+        changed = true;
       } else {
         await (update(itemsTable)..where((tbl) => tbl.id.equals(item.id)))
             .write(data);
+        changed = true;
       }
     }
+    return changed;
   }
 
-  Future<void> _applyRemoteMemberships(
+  Future<bool> _applyRemoteMemberships(
       List<RemoteMembership> memberships) async {
+    var changed = false;
     for (final membership in memberships) {
       final existing = await (select(spaceMembershipsTable)
             ..where((tbl) =>
@@ -1077,14 +1095,17 @@ class LocalDatabase extends _$LocalDatabase {
           ),
           mode: InsertMode.insertOrReplace,
         );
+        changed = true;
       } else {
         await (update(spaceMembershipsTable)
               ..where((tbl) =>
                   tbl.spaceId.equals(membership.spaceId) &
                   tbl.userId.equals(membership.userId)))
             .write(data);
+        changed = true;
       }
     }
+    return changed;
   }
 
   Future<void> dispose() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,9 @@ Future<void> main() async {
   final syncService = SyncService(
     database: database,
     apiClient: remoteApiClient,
+    onRemoteChange: () async {
+      await SpaceModel.loadItems();
+    },
   );
 
   final themeController = ThemeController();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:sqlite3_flutter_libs/sqlite3_flutter_libs.dart'
+    as sqlite_libraries;
 
 import 'data/local_database.dart';
 import 'data/remote/remote_api_client.dart';
@@ -13,6 +15,7 @@ import 'theme/theme_controller.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await sqlite_libraries.applyWorkaroundToOpenSqlite3OnOldAndroidVersions();
 
   final database = LocalDatabase();
   final repository = SpacesRepository(database: database);

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -191,9 +191,17 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
+    return ValueListenableBuilder<List<SpaceModel>>(
+      valueListenable: SpaceModel.spacesListenable,
+      builder: (context, spaces, _) {
+        return _buildScaffold(context, spaces);
+      },
+    );
+  }
+
+  Widget _buildScaffold(BuildContext context, List<SpaceModel> spaces) {
     final theme = Theme.of(context);
     final extras = theme.extension<AppThemeColors>()!;
-    final spaces = SpaceModel.currentSpaces;
 
     return Scaffold(
       extendBodyBehindAppBar: true,

--- a/lib/pages/search.dart
+++ b/lib/pages/search.dart
@@ -47,54 +47,61 @@ class _SearchPageState extends State<SearchPage> {
 
   @override
   Widget build(BuildContext context) {
-    getItems();
-    List<ItemModel> filteredItems = getFilteredItems();
-    final theme = Theme.of(context);
-    final extras = theme.extension<AppThemeColors>()!;
+    return ValueListenableBuilder<List<SpaceModel>>(
+      valueListenable: SpaceModel.spacesListenable,
+      builder: (context, spaces, _) {
+        places = spaces;
+        getItems();
+        final filteredItems = getFilteredItems();
+        final theme = Theme.of(context);
+        final extras = theme.extension<AppThemeColors>()!;
 
-    return Scaffold(
-      body: Container(
-        decoration: BoxDecoration(gradient: extras.backgroundGradient),
-        child: SafeArea(
-          child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
-                child: searchBar(context),
-              ),
-              Expanded(
-                child: filteredItems.isEmpty
-                    ? _buildEmptyResults(theme, extras)
-                    : ListView.separated(
-                        padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-                        itemCount: filteredItems.length,
-                        separatorBuilder: (_, __) => const SizedBox(height: 12),
-                        itemBuilder: (context, index) {
-                          String parentName = '';
-                          if (filteredItems[index].parent != null) {
-                            parentName = filteredItems[index].parent!.name;
-                            if (filteredItems[index].parent!.parent != null) {
-                              parentName =
-                                  '${filteredItems[index].parent!.parent!.name} > $parentName';
-                              if (filteredItems[index].parent!.parent!.parent != null) {
-                                parentName =
-                                    '${filteredItems[index].parent!.parent!.parent!.name} > $parentName';
+        return Scaffold(
+          body: Container(
+            decoration: BoxDecoration(gradient: extras.backgroundGradient),
+            child: SafeArea(
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+                    child: searchBar(context),
+                  ),
+                  Expanded(
+                    child: filteredItems.isEmpty
+                        ? _buildEmptyResults(theme, extras)
+                        : ListView.separated(
+                            padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                            itemCount: filteredItems.length,
+                            separatorBuilder: (_, __) => const SizedBox(height: 12),
+                            itemBuilder: (context, index) {
+                              String parentName = '';
+                              if (filteredItems[index].parent != null) {
+                                parentName = filteredItems[index].parent!.name;
+                                if (filteredItems[index].parent!.parent != null) {
+                                  parentName =
+                                      '${filteredItems[index].parent!.parent!.name} > $parentName';
+                                  if (filteredItems[index].parent!.parent!.parent !=
+                                      null) {
+                                    parentName =
+                                        '${filteredItems[index].parent!.parent!.parent!.name} > $parentName';
+                                  }
+                                }
                               }
-                            }
-                          }
-                          return searchEntry(
-                            filteredItems,
-                            index,
-                            parentName,
-                            context,
-                          );
-                        },
-                      ),
+                              return searchEntry(
+                                filteredItems,
+                                index,
+                                parentName,
+                                context,
+                              );
+                            },
+                          ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -203,8 +203,9 @@ class _SettingsPageState extends State<SettingsPage> {
         File file = File(result.files.single.path!);
         String content = await file.readAsString();
         List<dynamic> json = jsonDecode(content);
-        SpaceModel.currentSpaces =
+        final importedSpaces =
             json.map((data) => SpaceModel.fromJson(data)).toList();
+        SpaceModel.updateCurrentSpaces(importedSpaces);
         final saved = await SpaceModel.saveItems();
         if (!mounted) return;
         if (!saved) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   intl: ^0.19.0
   path: ^1.8.3
   uuid: ^3.0.7
-  sqflite: ^2.2.8
   drift: ^2.4.0
   sqlite3_flutter_libs: ^0.5.20
 

--- a/test/space_model_test.dart
+++ b/test/space_model_test.dart
@@ -29,7 +29,7 @@ void main() {
   });
 
   tearDown(() {
-    SpaceModel.currentSpaces = [];
+    SpaceModel.updateCurrentSpaces(const <SpaceModel>[]);
     PathProviderPlatform.instance = originalPlatform;
   });
 
@@ -161,8 +161,7 @@ void main() {
         ],
       );
 
-      SpaceModel.currentSpaces = [office];
-      office.assignParents();
+      SpaceModel.updateCurrentSpaces([office]);
 
       final success = await SpaceModel.saveItems();
       expect(success, isTrue);
@@ -170,7 +169,7 @@ void main() {
       final savedDatabase = File(p.join(tempDir.path, 'spaces.db'));
       expect(savedDatabase.existsSync(), isTrue);
 
-      SpaceModel.currentSpaces = [];
+      SpaceModel.updateCurrentSpaces(const <SpaceModel>[]);
 
       await SpaceModel.loadItems();
 


### PR DESCRIPTION
## Summary
- ensure the bundled sqlite3 library is opened on Android before the database starts
- persist the remote sync cursor inside the local database and expose helpers to read/update it
- update the sync service to reuse the stored cursor between runs and extend the tests to cover the new behaviour

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3c5f17310832a82ecc9be2d8f2952